### PR TITLE
Add support for multiple gateway names

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ gatus-sidecar [options]
 |------|---------|-------------|
 | `--namespace` | `""` | Namespace to watch (empty for all namespaces) |
 | `--gateway-name` | `""` | Gateway name to filter HTTPRoutes |
+| `--gateway-names` | `""` | Comma-separated gateway names to filter HTTPRoutes |
 | `--ingress-class` | `""` | Ingress class to filter Ingresses |
 | `--enable-httproute` | `false` | Enable HTTPRoute endpoint creation |
 | `--enable-ingress` | `false` | Enable Ingress endpoint creation |
@@ -65,6 +66,10 @@ Monitor Gateway API HTTPRoute resources:
 
 ```bash
 gatus-sidecar --auto-httproute --gateway-name=my-gateway
+```
+
+```bash
+gatus-sidecar --auto-httproute --gateway-names=my-gateway,my-gateway-2
 ```
 
 ### 🔀 Ingress Mode

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	Mode               string
 	Namespace          string
 	GatewayName        string
+	GatewayNames       string
 	IngressClass       string
 	EnableHTTPRoute    bool
 	EnableIngress      bool
@@ -29,6 +30,7 @@ func Load() *Config {
 
 	flag.StringVar(&cfg.Namespace, "namespace", "", "Namespace to watch (empty for all)")
 	flag.StringVar(&cfg.GatewayName, "gateway-name", "", "Gateway name to filter HTTPRoutes (optional)")
+	flag.StringVar(&cfg.GatewayNames, "gateway-names", "", "Comma-separated gateway names to filter HTTPRoutes (optional)")
 	flag.StringVar(&cfg.IngressClass, "ingress-class", "", "Ingress class to filter Ingresses (optional)")
 	flag.BoolVar(&cfg.EnableHTTPRoute, "enable-httproute", false, "Enable HTTPRoute endpoint generation")
 	flag.BoolVar(&cfg.EnableIngress, "enable-ingress", false, "Enable Ingress endpoint generation")

--- a/internal/resources/httproute/httproute.go
+++ b/internal/resources/httproute/httproute.go
@@ -47,11 +47,47 @@ func filterFunc(obj metav1.Object, cfg *config.Config) bool {
 	}
 
 	// Check gateway filter if configured
+	if cfg.GatewayName != "" && referencesGateway(route, cfg.GatewayName) {
+		return true
+	}
+
+	gatewayNames := parseGatewayNames(cfg.GatewayNames)
+	if len(gatewayNames) > 0 {
+		return referencesAnyGateway(route, gatewayNames)
+	}
+
 	if cfg.GatewayName != "" {
-		return referencesGateway(route, cfg.GatewayName)
+		return false
 	}
 
 	return true
+}
+
+func parseGatewayNames(gatewayNames string) []string {
+	if gatewayNames == "" {
+		return nil
+	}
+
+	parsed := make([]string, 0, len(strings.Split(gatewayNames, ",")))
+	for _, gatewayName := range strings.Split(gatewayNames, ",") {
+		gatewayName = strings.TrimSpace(gatewayName)
+		if gatewayName == "" {
+			continue
+		}
+		parsed = append(parsed, gatewayName)
+	}
+
+	return parsed
+}
+
+func referencesAnyGateway(route *gatewayv1.HTTPRoute, gatewayNames []string) bool {
+	for _, gatewayName := range gatewayNames {
+		if referencesGateway(route, gatewayName) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func urlExtractor(obj metav1.Object) string {

--- a/internal/resources/httproute/httproute_test.go
+++ b/internal/resources/httproute/httproute_test.go
@@ -1,6 +1,7 @@
 package httproute
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/home-operations/gatus-sidecar/internal/config"
@@ -154,6 +155,69 @@ func TestFilterFunc(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "filter by gateway names matches",
+			obj: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: otherGateway},
+						},
+					},
+				},
+			},
+			cfg:  &config.Config{GatewayNames: "my-gateway,other-gateway"},
+			want: true,
+		},
+		{
+			name: "filter by gateway names trims spaces",
+			obj: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: otherGateway},
+						},
+					},
+				},
+			},
+			cfg:  &config.Config{GatewayNames: "my-gateway, other-gateway"},
+			want: true,
+		},
+		{
+			name: "filter by gateway names does not match",
+			obj: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: gatewayName},
+						},
+					},
+				},
+			},
+			cfg:  &config.Config{GatewayNames: "other-gateway,another-gateway"},
+			want: false,
+		},
+		{
+			name: "filter by combined gateway flags matches either option",
+			obj: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: otherGateway},
+						},
+					},
+				},
+			},
+			cfg: &config.Config{
+				GatewayName:  "missing-gateway",
+				GatewayNames: "other-gateway,another-gateway",
+			},
+			want: true,
+		},
+		{
 			name: "no parent refs passes filter when no gateway filter",
 			obj: &gatewayv1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
@@ -175,6 +239,34 @@ func TestFilterFunc(t *testing.T) {
 			got := filterFunc(tt.obj, tt.cfg)
 			if got != tt.want {
 				t.Errorf("filterFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGatewayNames(t *testing.T) {
+	tests := []struct {
+		name         string
+		gatewayNames string
+		want         []string
+	}{
+		{
+			name:         "empty string returns nil",
+			gatewayNames: "",
+			want:         nil,
+		},
+		{
+			name:         "comma separated names are trimmed",
+			gatewayNames: "first-gateway, second-gateway , ,third-gateway",
+			want:         []string{"first-gateway", "second-gateway", "third-gateway"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGatewayNames(tt.gatewayNames)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseGatewayNames() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -354,6 +446,56 @@ func TestReferencesGateway(t *testing.T) {
 			got := referencesGateway(tt.route, tt.gatewayName)
 			if got != tt.want {
 				t.Errorf("referencesGateway() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReferencesAnyGateway(t *testing.T) {
+	targetGateway := gatewayv1.ObjectName("target-gateway")
+	otherGateway := gatewayv1.ObjectName("other-gateway")
+
+	tests := []struct {
+		name         string
+		route        *gatewayv1.HTTPRoute
+		gatewayNames []string
+		want         bool
+	}{
+		{
+			name: "references one of multiple gateways",
+			route: &gatewayv1.HTTPRoute{
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: targetGateway},
+						},
+					},
+				},
+			},
+			gatewayNames: []string{"missing-gateway", "target-gateway"},
+			want:         true,
+		},
+		{
+			name: "does not reference any gateway",
+			route: &gatewayv1.HTTPRoute{
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: otherGateway},
+						},
+					},
+				},
+			},
+			gatewayNames: []string{"missing-gateway", "target-gateway"},
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := referencesAnyGateway(tt.route, tt.gatewayNames)
+			if got != tt.want {
+				t.Errorf("referencesAnyGateway() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Adds --gateway-names for comma-separated HTTPRoute filtering while keeping the existing --gateway-name behavior unchanged.