### PR TITLE
refactor: tighten hot paths and tidy tests

### DIFF
--- a/internal/gatus/writer.go
+++ b/internal/gatus/writer.go
@@ -47,12 +47,7 @@ func (w *Writer) Upsert(key string, e *Endpoint, flush bool) (bool, error) {
 		w.dirty = true
 		changed = true
 	}
-	if flush && w.dirty {
-		if err := w.flushLocked(); err != nil {
-			return changed, err
-		}
-	}
-	return changed, nil
+	return changed, w.flushIfDirty(flush)
 }
 
 // Delete drops the endpoint stored under key. The bool reports whether a
@@ -68,12 +63,7 @@ func (w *Writer) Delete(key string, flush bool) (bool, error) {
 		w.dirty = true
 		removed = true
 	}
-	if flush && w.dirty {
-		if err := w.flushLocked(); err != nil {
-			return removed, err
-		}
-	}
-	return removed, nil
+	return removed, w.flushIfDirty(flush)
 }
 
 // Flush forces the current state to disk.
@@ -83,6 +73,13 @@ func (w *Writer) Flush() error {
 	return w.flushLocked()
 }
 
+func (w *Writer) flushIfDirty(flush bool) error {
+	if flush && w.dirty {
+		return w.flushLocked()
+	}
+	return nil
+}
+
 func (w *Writer) Len() int {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -90,8 +87,9 @@ func (w *Writer) Len() int {
 }
 
 func (w *Writer) flushLocked() error {
-	endpoints := slices.Collect(maps.Values(w.endpoints))
-	slices.SortFunc(endpoints, func(a, b *Endpoint) int { return cmp.Compare(a.Name, b.Name) })
+	endpoints := slices.SortedFunc(maps.Values(w.endpoints), func(a, b *Endpoint) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 
 	data, err := yaml.Marshal(map[string]any{"endpoints": endpoints})
 	if err != nil {

--- a/internal/gatus/writer_test.go
+++ b/internal/gatus/writer_test.go
@@ -25,7 +25,6 @@ func TestWriter_UpsertAndDelete(t *testing.T) {
 		t.Error("first Upsert should report changed=true")
 	}
 
-	// identical second upsert: no change.
 	changed, err = w.Upsert("k1", &Endpoint{Name: "a", URL: "https://a", Interval: "1m"}, true)
 	if err != nil {
 		t.Fatalf("Upsert err: %v", err)
@@ -34,7 +33,6 @@ func TestWriter_UpsertAndDelete(t *testing.T) {
 		t.Error("equal Upsert should report changed=false")
 	}
 
-	// update.
 	changed, err = w.Upsert("k1", &Endpoint{Name: "a", URL: "https://b", Interval: "1m"}, true)
 	if err != nil {
 		t.Fatalf("Upsert err: %v", err)
@@ -43,7 +41,6 @@ func TestWriter_UpsertAndDelete(t *testing.T) {
 		t.Error("Upsert with new URL should report changed=true")
 	}
 
-	// delete.
 	removed, err := w.Delete("k1", true)
 	if err != nil {
 		t.Fatalf("Delete err: %v", err)
@@ -70,8 +67,8 @@ func TestWriter_Flush_SortsAndMatchesYAMLShape(t *testing.T) {
 		{Name: "alpha", URL: "a", Interval: "1m", Conditions: []string{"[STATUS] == 200"}},
 		{Name: "mid", URL: "m", Interval: "1m"},
 	}
-	for i, e := range endpoints {
-		if _, err := w.Upsert(e.Name+string(rune('0'+i)), e, false); err != nil {
+	for _, e := range endpoints {
+		if _, err := w.Upsert(e.Name, e, false); err != nil {
 			t.Fatalf("Upsert: %v", err)
 		}
 	}
@@ -84,7 +81,6 @@ func TestWriter_Flush_SortsAndMatchesYAMLShape(t *testing.T) {
 		t.Fatalf("ReadFile: %v", err)
 	}
 
-	// alphabetical ordering.
 	out := string(data)
 	if !strings.Contains(out, "alpha") || strings.Index(out, "alpha") > strings.Index(out, "mid") {
 		t.Error("alpha should appear before mid")
@@ -93,7 +89,6 @@ func TestWriter_Flush_SortsAndMatchesYAMLShape(t *testing.T) {
 		t.Error("mid should appear before zebra")
 	}
 
-	// valid YAML shape.
 	var doc struct {
 		Endpoints []map[string]any `yaml:"endpoints"`
 	}
@@ -113,7 +108,6 @@ func TestWriter_FlushIsAtomic(t *testing.T) {
 		t.Fatalf("Upsert: %v", err)
 	}
 
-	// no tmp files left behind.
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("ReadDir: %v", err)
@@ -131,12 +125,10 @@ func TestWriter_Concurrent(t *testing.T) {
 	w := NewWriter(path)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 50 {
+		wg.Go(func() {
 			_, _ = w.Upsert("k", &Endpoint{Name: "a", URL: "x", Interval: "1m"}, true)
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -145,10 +145,11 @@ func (c *Controller) processNext(ctx context.Context) bool {
 	defer c.queue.Done(key)
 
 	if err := c.reconcile(ctx, key, true); err != nil {
-		if c.queue.NumRequeues(key) < defaultMaxRetry {
+		retries := c.queue.NumRequeues(key)
+		if retries < defaultMaxRetry {
 			slog.Warn("reconcile failed, requeueing",
 				"resource", c.Resource(), "key", key, "error", err,
-				"retries", c.queue.NumRequeues(key))
+				"retries", retries)
 			c.queue.AddRateLimited(key)
 			return true
 		}

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -316,7 +316,6 @@ func TestController_TemplateInheritanceAndGuarded(t *testing.T) {
 		t.Fatalf("expected 1 endpoint, got %d", writer.Len())
 	}
 
-	// Now read the file and verify the merged endpoint.
 	data, err := os.ReadFile(outPath)
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)

--- a/internal/k8s/fetcher.go
+++ b/internal/k8s/fetcher.go
@@ -40,7 +40,7 @@ type cachedFetcher struct {
 	client dynamic.Interface
 	ttl    time.Duration
 
-	mu    sync.Mutex
+	mu    sync.RWMutex
 	cache map[string]fetcherEntry
 }
 
@@ -48,16 +48,17 @@ func (f *cachedFetcher) GetAnnotations(ctx context.Context, gvr schema.GroupVers
 	key := gvr.String() + "/" + namespace + "/" + name
 	now := time.Now()
 
-	f.mu.Lock()
-	if entry, ok := f.cache[key]; ok && now.Before(entry.expires) {
-		f.mu.Unlock()
+	f.mu.RLock()
+	entry, ok := f.cache[key]
+	f.mu.RUnlock()
+	if ok && now.Before(entry.expires) {
 		return entry.annotations
 	}
-	f.mu.Unlock()
 
-	var iface dynamic.ResourceInterface = f.client.Resource(gvr)
+	res := f.client.Resource(gvr)
+	var iface dynamic.ResourceInterface = res
 	if namespace != "" {
-		iface = f.client.Resource(gvr).Namespace(namespace)
+		iface = res.Namespace(namespace)
 	}
 
 	var ann map[string]string

--- a/internal/resources/httproute.go
+++ b/internal/resources/httproute.go
@@ -110,8 +110,8 @@ func firstHTTPRoutePath(route *gatewayv1.HTTPRoute) string {
 			if match.Path.Type != nil && *match.Path.Type == gatewayv1.PathMatchRegularExpression {
 				continue
 			}
-			if isProbablePath(*match.Path.Value) {
-				return *match.Path.Value
+			if value := *match.Path.Value; isProbablePath(value) {
+				return value
 			}
 		}
 	}

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -87,21 +87,19 @@ func (Ingress) ParentAnnotations(ctx context.Context, obj metav1.Object, fetcher
 
 // firstIngressHostAndPath returns the first non-empty hostname and the first
 // probable path under it. Path is "" when the rule has no usable path.
-func firstIngressHostAndPath(ing *networkingv1.Ingress) (host, path string) {
+func firstIngressHostAndPath(ing *networkingv1.Ingress) (string, string) {
 	for _, rule := range ing.Spec.Rules {
 		if rule.Host == "" {
 			continue
 		}
-		host = rule.Host
-		if rule.HTTP == nil {
-			return host, ""
-		}
-		for _, p := range rule.HTTP.Paths {
-			if isProbablePath(p.Path) {
-				return host, p.Path
+		if rule.HTTP != nil {
+			for _, p := range rule.HTTP.Paths {
+				if isProbablePath(p.Path) {
+					return rule.Host, p.Path
+				}
 			}
 		}
-		return host, ""
+		return rule.Host, ""
 	}
 	return "", ""
 }

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -51,7 +51,7 @@ func All(cfg *config.Config) []k8s.Resource {
 	if !cfg.AnyExplicitlyEnabled() {
 		return []k8s.Resource{Ingress{}, HTTPRoute{}, Service{}, IngressRoute{}}
 	}
-	var out []k8s.Resource
+	out := make([]k8s.Resource, 0, 4)
 	if cfg.EnableIngress || cfg.AutoIngress {
 		out = append(out, Ingress{})
 	}

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -44,7 +44,7 @@ func (Service) URL(obj metav1.Object) string {
 		return ""
 	}
 	port := svc.Spec.Ports[0]
-	protocol := cmp.Or(strings.ToLower(string(port.Protocol)), "tcp")
+	protocol := strings.ToLower(string(cmp.Or(port.Protocol, corev1.ProtocolTCP)))
 	return fmt.Sprintf("%s://%s.%s.svc:%d", protocol, svc.Name, svc.Namespace, port.Port)
 }
 


### PR DESCRIPTION
## Summary

Small, behavior-preserving cleanups across the sidecar. No CLI flag, annotation, generated-URL, or YAML-shape change.

(The earlier draft of this PR also relaxed `isProbablePath` to accept `/` as a probe target. That part is withdrawn — the auto-extracted URL for a `/`-only Ingress / HTTPRoute / IngressRoute would have been functionally identical to the bare host but visually different, and the existing `--probe-paths=false` / `path:` template directive already covers the cases that actually matter for probe behavior.)

### Hot-path tightening

- **`internal/k8s/fetcher.go`** — cache mutex → `sync.RWMutex`; cache hits no longer serialize on a write lock. Also collapses the duplicated `f.client.Resource(gvr)` call on the miss path.
- **`internal/k8s/controller.go`** — cache `c.queue.NumRequeues(key)` so the warn path doesn't call it twice (comparison + log field).
- **`internal/gatus/writer.go`** — extract a tiny `flushIfDirty` helper; `Upsert` and `Delete` were duplicating the post-mutation `if flush && dirty { flushLocked }` block. `flushLocked` now uses `slices.SortedFunc` instead of `slices.Collect` + `SortFunc`.
- **`internal/resources/resources.go`** — pre-allocate the result slice in `All()` (cap is fixed at 4).
- **`internal/resources/service.go`** — apply `strings.ToLower` once outside `cmp.Or` and use the `corev1.ProtocolTCP` constant for the fallback.
- **`internal/resources/ingress.go`** — drop named returns in `firstIngressHostAndPath`; return `rule.Host` directly so the assignment + empty-HTTP early return collapse.
- **`internal/resources/httproute.go`** — cache `*match.Path.Value` rather than dereferencing the same pointer for both the predicate and the return.

### Test tidy

- `TestWriter_Concurrent` uses `for range 50` and `wg.Go` (Go 1.25+).
- `TestWriter_Flush_SortsAndMatchesYAMLShape` uses each endpoint's `Name` as the upsert key directly — the synthesized suffix wasn't needed since the names are already distinct.
- Drop a handful of section-label comments that just labeled the following block (`// update.`, `// delete.`, `// alphabetical ordering.`, etc.) and one `// Now read the file...` comment that restated the next line of code.

## Test plan

- [x] `go test ./... -race -count=1` — all packages green
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] Net diff: -11 lines; 9 files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)