### PR TITLE
refactor: data-driven kind registry, scoped logging, test hardening

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -15,7 +15,7 @@ run = "go vet ./..."
 
 [tasks.test]
 description = "Run tests with coverage"
-run = "go test $(go list ./...) -coverprofile cover.out"
+run = "go test -race $(go list ./...) -coverprofile cover.out"
 
 [tasks.lint]
 description = "Run golangci-lint"

--- a/cmd/gatus-sidecar/main.go
+++ b/cmd/gatus-sidecar/main.go
@@ -61,7 +61,6 @@ func run(name string, args []string) error {
 	for _, r := range enabled {
 		c := k8s.NewController(cfg, r, writer, dc)
 		wg.Go(func() {
-			slog.Info("controller starting", "resource", c.Resource())
 			if err := c.Run(ctx); err != nil {
 				slog.Error("controller stopped", "resource", c.Resource(), "error", err)
 				cancel()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,20 +18,40 @@ const (
 	DefaultLogLevel           = "info"
 )
 
+// Kind identifiers — the canonical set of watchable resource kinds. The values
+// double as the suffix of the per-kind flags (e.g. KindIngress → --enable-ingress).
+const (
+	KindIngress      = "ingress"
+	KindHTTPRoute    = "httproute"
+	KindService      = "service"
+	KindIngressRoute = "ingressroute"
+)
+
+// kindMeta drives per-kind flag registration and help text.
+var kindMeta = []struct {
+	name    string
+	display string
+	plural  string
+}{
+	{KindIngress, "Ingress", "Ingresses"},
+	{KindHTTPRoute, "HTTPRoute", "HTTPRoutes"},
+	{KindService, "Service", "Services"},
+	{KindIngressRoute, "Traefik IngressRoute", "Traefik IngressRoutes"},
+}
+
+// KindConfig holds the per-kind flag values.
+type KindConfig struct {
+	Enable bool
+	Auto   bool
+	Prefix string
+}
+
 type Config struct {
 	Namespace      string
 	GatewayNames   StringSet
 	IngressClasses StringSet
 
-	EnableHTTPRoute    bool
-	EnableIngress      bool
-	EnableService      bool
-	EnableIngressRoute bool
-
-	AutoHTTPRoute    bool
-	AutoIngress      bool
-	AutoService      bool
-	AutoIngressRoute bool
+	Kinds map[string]*KindConfig
 
 	Output          string
 	DefaultInterval time.Duration
@@ -39,11 +59,6 @@ type Config struct {
 
 	TemplateAnnotation string
 	EnabledAnnotation  string
-
-	IngressPrefix      string
-	ServicePrefix      string
-	HTTPRoutePrefix    string
-	IngressRoutePrefix string
 
 	LogLevel slog.Level
 }
@@ -58,26 +73,20 @@ func Load(name string, args []string, errOut io.Writer) (*Config, error) {
 	fs.Var(&cfg.GatewayNames, "gateway-name", "Gateway name(s) to filter HTTPRoutes; may be repeated")
 	fs.Var(&cfg.IngressClasses, "ingress-class", "Ingress class(es) to filter Ingresses; may be repeated")
 
-	fs.BoolVar(&cfg.EnableHTTPRoute, "enable-httproute", false, "Enable HTTPRoute endpoint generation")
-	fs.BoolVar(&cfg.EnableIngress, "enable-ingress", false, "Enable Ingress endpoint generation")
-	fs.BoolVar(&cfg.EnableService, "enable-service", false, "Enable Service endpoint generation")
-	fs.BoolVar(&cfg.EnableIngressRoute, "enable-ingressroute", false, "Enable Traefik IngressRoute endpoint generation")
-
-	fs.BoolVar(&cfg.AutoHTTPRoute, "auto-httproute", false, "Automatically create endpoints for HTTPRoutes")
-	fs.BoolVar(&cfg.AutoIngress, "auto-ingress", false, "Automatically create endpoints for Ingresses")
-	fs.BoolVar(&cfg.AutoService, "auto-service", false, "Automatically create endpoints for Services")
-	fs.BoolVar(&cfg.AutoIngressRoute, "auto-ingressroute", false, "Automatically create endpoints for Traefik IngressRoutes")
+	cfg.Kinds = make(map[string]*KindConfig, len(kindMeta))
+	for _, k := range kindMeta {
+		kc := &KindConfig{}
+		cfg.Kinds[k.name] = kc
+		fs.BoolVar(&kc.Enable, "enable-"+k.name, false, fmt.Sprintf("Enable %s endpoint generation", k.display))
+		fs.BoolVar(&kc.Auto, "auto-"+k.name, false, fmt.Sprintf("Automatically create endpoints for %s", k.plural))
+		fs.StringVar(&kc.Prefix, "prefix-"+k.name, "", fmt.Sprintf("Prefix prepended to generated endpoint names for %s resources", k.display))
+	}
 
 	fs.StringVar(&cfg.Output, "output", DefaultOutputPath, "File to write generated YAML")
 	fs.DurationVar(&cfg.DefaultInterval, "default-interval", DefaultInterval, "Default interval value for endpoints")
 	fs.BoolVar(&cfg.ProbePaths, "probe-paths", true, "Include paths from Ingress/HTTPRoute/IngressRoute match rules in probe URLs; set false to probe bare hostnames")
 	fs.StringVar(&cfg.TemplateAnnotation, "annotation-config", DefaultTemplateAnnotation, "Annotation key for YAML config override")
 	fs.StringVar(&cfg.EnabledAnnotation, "annotation-enabled", DefaultEnabledAnnotation, "Annotation key for enabling/disabling resource processing")
-
-	fs.StringVar(&cfg.IngressPrefix, "prefix-ingress", "", "Prefix prepended to generated endpoint names for Ingress resources")
-	fs.StringVar(&cfg.ServicePrefix, "prefix-service", "", "Prefix prepended to generated endpoint names for Service resources")
-	fs.StringVar(&cfg.HTTPRoutePrefix, "prefix-httproute", "", "Prefix prepended to generated endpoint names for HTTPRoute resources")
-	fs.StringVar(&cfg.IngressRoutePrefix, "prefix-ingressroute", "", "Prefix prepended to generated endpoint names for Traefik IngressRoute resources")
 
 	logLevel := fs.String("log-level", DefaultLogLevel, "Log level: debug, info, warn, error")
 
@@ -117,6 +126,31 @@ func parseLogLevel(s string) (slog.Level, error) {
 
 // AnyExplicitlyEnabled reports whether any --enable-* or --auto-* flag is set.
 func (c *Config) AnyExplicitlyEnabled() bool {
-	return c.EnableHTTPRoute || c.EnableIngress || c.EnableService || c.EnableIngressRoute ||
-		c.AutoHTTPRoute || c.AutoIngress || c.AutoService || c.AutoIngressRoute
+	for _, k := range c.Kinds {
+		if k.Enable || k.Auto {
+			return true
+		}
+	}
+	return false
+}
+
+// KindEnabled reports whether the named kind is enabled by either its
+// --enable-<kind> or --auto-<kind> flag.
+func (c *Config) KindEnabled(name string) bool {
+	k := c.Kinds[name]
+	return k != nil && (k.Enable || k.Auto)
+}
+
+// AutoEnabled reports whether the named kind is in auto-discovery mode.
+func (c *Config) AutoEnabled(name string) bool {
+	k := c.Kinds[name]
+	return k != nil && k.Auto
+}
+
+// Prefix returns the endpoint-name prefix configured for the named kind.
+func (c *Config) Prefix(name string) string {
+	if k := c.Kinds[name]; k != nil {
+		return k.Prefix
+	}
+	return ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestLoad_Defaults(t *testing.T) {
+	t.Parallel()
 	cfg, err := Load("gatus-sidecar", nil, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
@@ -28,6 +29,7 @@ func TestLoad_Defaults(t *testing.T) {
 }
 
 func TestLoad_AllFlags(t *testing.T) {
+	t.Parallel()
 	args := []string{
 		"--namespace=ns",
 		"--gateway-name=gw1",
@@ -50,7 +52,7 @@ func TestLoad_AllFlags(t *testing.T) {
 		!reflect.DeepEqual([]string(cfg.IngressClasses), []string{"nginx", "traefik"}) {
 		t.Errorf("filter flags incorrect: %+v", cfg)
 	}
-	if !cfg.EnableHTTPRoute || !cfg.AutoIngress {
+	if !cfg.Kinds[KindHTTPRoute].Enable || !cfg.Kinds[KindIngress].Auto {
 		t.Errorf("enable flags incorrect: %+v", cfg)
 	}
 	if cfg.Output != "/tmp/foo.yaml" {
@@ -68,6 +70,7 @@ func TestLoad_AllFlags(t *testing.T) {
 }
 
 func TestLoad_RejectsBadValues(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		args []string
@@ -78,6 +81,7 @@ func TestLoad_RejectsBadValues(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := Load("test", tt.args, &bytes.Buffer{})
 			if err == nil {
 				t.Errorf("expected error for args %v", tt.args)
@@ -87,6 +91,7 @@ func TestLoad_RejectsBadValues(t *testing.T) {
 }
 
 func TestLoad_LogLevel(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		arg     string
 		want    slog.Level
@@ -102,6 +107,7 @@ func TestLoad_LogLevel(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.arg, func(t *testing.T) {
+			t.Parallel()
 			args := []string{}
 			if tt.arg != "" {
 				args = append(args, "--log-level="+tt.arg)
@@ -118,18 +124,20 @@ func TestLoad_LogLevel(t *testing.T) {
 }
 
 func TestAnyExplicitlyEnabled(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		cfg  Config
 		want bool
 	}{
 		{"none", Config{}, false},
-		{"enable-ingress", Config{EnableIngress: true}, true},
-		{"auto-service", Config{AutoService: true}, true},
-		{"auto-ingressroute", Config{AutoIngressRoute: true}, true},
+		{"enable-ingress", Config{Kinds: map[string]*KindConfig{KindIngress: {Enable: true}}}, true},
+		{"auto-service", Config{Kinds: map[string]*KindConfig{KindService: {Auto: true}}}, true},
+		{"auto-ingressroute", Config{Kinds: map[string]*KindConfig{KindIngressRoute: {Auto: true}}}, true},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := tt.cfg.AnyExplicitlyEnabled(); got != tt.want {
 				t.Errorf("AnyExplicitlyEnabled() = %v, want %v", got, tt.want)
 			}

--- a/internal/config/stringset_test.go
+++ b/internal/config/stringset_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestStringSet_Set(t *testing.T) {
+	t.Parallel()
 	var s StringSet
 	for _, v := range []string{"a", "b", "a", "c", ""} {
 		if err := s.Set(v); err != nil {
@@ -19,6 +20,7 @@ func TestStringSet_Set(t *testing.T) {
 }
 
 func TestStringSet_Contains(t *testing.T) {
+	t.Parallel()
 	s := StringSet{"a", "b"}
 	if !s.Contains("a") {
 		t.Error("Contains(a) should be true")
@@ -29,6 +31,7 @@ func TestStringSet_Contains(t *testing.T) {
 }
 
 func TestStringSet_String(t *testing.T) {
+	t.Parallel()
 	s := StringSet{"a", "b"}
 	if got := s.String(); got != "a,b" {
 		t.Errorf("String() = %q, want a,b", got)
@@ -40,6 +43,7 @@ func TestStringSet_String(t *testing.T) {
 }
 
 func TestStringSet_ImplementsFlagValue(t *testing.T) {
+	t.Parallel()
 	var s StringSet
 	var _ flag.Value = &s
 	fs := flag.NewFlagSet("t", flag.ContinueOnError)

--- a/internal/gatus/dns_test.go
+++ b/internal/gatus/dns_test.go
@@ -3,7 +3,9 @@ package gatus
 import "testing"
 
 func TestApplyGuardedDNS(t *testing.T) {
+	t.Parallel()
 	t.Run("populates fields", func(t *testing.T) {
+		t.Parallel()
 		e := &Endpoint{}
 		ApplyGuardedDNS("example.com", e)
 		if e.URL != GuardedProbeURL {
@@ -18,6 +20,7 @@ func TestApplyGuardedDNS(t *testing.T) {
 	})
 
 	t.Run("empty host is no-op", func(t *testing.T) {
+		t.Parallel()
 		e := &Endpoint{}
 		ApplyGuardedDNS("", e)
 		if e.URL != "" || e.DNS != nil || e.Conditions != nil {
@@ -26,6 +29,7 @@ func TestApplyGuardedDNS(t *testing.T) {
 	})
 
 	t.Run("nil endpoint is no-op", func(t *testing.T) {
+		t.Parallel()
 		// just verify it doesn't panic
 		ApplyGuardedDNS("example.com", nil)
 	})

--- a/internal/gatus/endpoint_test.go
+++ b/internal/gatus/endpoint_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestEndpoint_ApplyTemplate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		in   *Endpoint
@@ -81,6 +82,7 @@ func TestEndpoint_ApplyTemplate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tt.in.ApplyTemplate(tt.tmpl)
 			if !reflect.DeepEqual(tt.in, tt.want) {
 				t.Errorf("ApplyTemplate mismatch\n got=%+v\nwant=%+v", tt.in, tt.want)
@@ -90,6 +92,7 @@ func TestEndpoint_ApplyTemplate(t *testing.T) {
 }
 
 func TestToStringSlice_DropsNonStringElements(t *testing.T) {
+	t.Parallel()
 	got := toStringSlice([]any{"a", 1, "b"})
 	want := []string{"a", "b"}
 	if !reflect.DeepEqual(got, want) {
@@ -98,6 +101,7 @@ func TestToStringSlice_DropsNonStringElements(t *testing.T) {
 }
 
 func TestToStringSlice_NilForUnknown(t *testing.T) {
+	t.Parallel()
 	if got := toStringSlice(12345); got != nil {
 		t.Errorf("toStringSlice(12345) = %v, want nil", got)
 	}

--- a/internal/gatus/golden_test.go
+++ b/internal/gatus/golden_test.go
@@ -11,6 +11,7 @@ import (
 // to the marshalled output requires updating the golden string here, so that
 // downstream gatus configuration breakage is caught at compile-test time.
 func TestWriter_GoldenOutput(t *testing.T) {
+	t.Parallel()
 	w := NewWriter(filepath.Join(t.TempDir(), "out.yaml"))
 
 	e := &Endpoint{

--- a/internal/gatus/template_test.go
+++ b/internal/gatus/template_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestParseTemplate(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name    string
 		in      string
@@ -18,6 +19,7 @@ func TestParseTemplate(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := ParseTemplate(tt.in)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ParseTemplate err=%v wantErr=%v", err, tt.wantErr)
@@ -30,6 +32,7 @@ func TestParseTemplate(t *testing.T) {
 }
 
 func TestMergeTemplates(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name          string
 		parent, child map[string]any
@@ -68,6 +71,7 @@ func TestMergeTemplates(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := MergeTemplates(tt.parent, tt.child)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("got=%v want=%v", got, tt.want)
@@ -77,6 +81,7 @@ func TestMergeTemplates(t *testing.T) {
 }
 
 func TestIsGuarded(t *testing.T) {
+	t.Parallel()
 	if IsGuarded(nil) {
 		t.Error("nil data should not be guarded")
 	}
@@ -89,6 +94,7 @@ func TestIsGuarded(t *testing.T) {
 }
 
 func TestPathOverride(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name   string
 		data   map[string]any
@@ -103,6 +109,7 @@ func TestPathOverride(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, ok := PathOverride(tt.data)
 			if got != tt.want || ok != tt.wantOK {
 				t.Errorf("PathOverride() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.wantOK)

--- a/internal/gatus/writer_test.go
+++ b/internal/gatus/writer_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestWriter_UpsertAndDelete(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.yaml")
 	w := NewWriter(path)
@@ -58,6 +59,7 @@ func TestWriter_UpsertAndDelete(t *testing.T) {
 }
 
 func TestWriter_Flush_SortsAndMatchesYAMLShape(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.yaml")
 	w := NewWriter(path)
@@ -101,6 +103,7 @@ func TestWriter_Flush_SortsAndMatchesYAMLShape(t *testing.T) {
 }
 
 func TestWriter_FlushIsAtomic(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.yaml")
 	w := NewWriter(path)
@@ -120,6 +123,7 @@ func TestWriter_FlushIsAtomic(t *testing.T) {
 }
 
 func TestWriter_Concurrent(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.yaml")
 	w := NewWriter(path)
@@ -138,6 +142,7 @@ func TestWriter_Concurrent(t *testing.T) {
 }
 
 func TestWriter_CreatesDirectories(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nested", "out.yaml")
 	w := NewWriter(path)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -37,6 +36,7 @@ type Controller struct {
 	fetcher  Fetcher
 	informer cache.SharedIndexInformer
 	queue    workqueue.TypedRateLimitingInterface[string]
+	log      *slog.Logger
 }
 
 func NewController(cfg *config.Config, r Resource, w *gatus.Writer, client dynamic.Interface) *Controller {
@@ -56,6 +56,7 @@ func NewController(cfg *config.Config, r Resource, w *gatus.Writer, client dynam
 		fetcher:  NewFetcher(client),
 		informer: informer,
 		queue:    queue,
+		log:      slog.With("resource", r.GVR().Resource),
 	}
 
 	_, _ = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -81,18 +82,19 @@ func (c *Controller) Resource() string {
 
 // Run blocks until ctx is cancelled.
 func (c *Controller) Run(ctx context.Context) error {
+	c.log.Info("controller starting")
 	go c.informer.Run(ctx.Done())
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.informer.HasSynced) {
 		return fmt.Errorf("cache sync failed for %s", c.Resource())
 	}
-	slog.Info("informer synced", "resource", c.Resource(), "count", len(c.informer.GetIndexer().ListKeys()))
+	c.log.Info("informer synced", "count", len(c.informer.GetIndexer().ListKeys()))
 
 	// Drain the queue once before workers start so the file is flushed once,
 	// not N times during initial sync.
 	c.initialReconcile(ctx)
 	if err := c.writer.Flush(); err != nil {
-		slog.Error("initial flush failed", "resource", c.Resource(), "error", err)
+		c.log.Error("initial flush failed", "error", err)
 	}
 
 	var wg sync.WaitGroup
@@ -126,7 +128,7 @@ func (c *Controller) initialReconcile(ctx context.Context) {
 func (c *Controller) enqueue(obj any) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		slog.Error("derive cache key", "resource", c.Resource(), "error", err)
+		c.log.Error("derive cache key", "error", err)
 		return
 	}
 	c.queue.Add(key)
@@ -147,14 +149,12 @@ func (c *Controller) processNext(ctx context.Context) bool {
 	if err := c.reconcile(ctx, key, true); err != nil {
 		retries := c.queue.NumRequeues(key)
 		if retries < defaultMaxRetry {
-			slog.Warn("reconcile failed, requeueing",
-				"resource", c.Resource(), "key", key, "error", err,
-				"retries", retries)
+			c.log.Warn("reconcile failed, requeueing",
+				"key", key, "error", err, "retries", retries)
 			c.queue.AddRateLimited(key)
 			return true
 		}
-		slog.Error("reconcile failed, giving up",
-			"resource", c.Resource(), "key", key, "error", err)
+		c.log.Error("reconcile failed, giving up", "key", key, "error", err)
 	}
 	c.queue.Forget(key)
 	return true
@@ -187,15 +187,14 @@ func (c *Controller) reconcile(ctx context.Context, key string, flush bool) erro
 		return fmt.Errorf("convert: %w", err)
 	}
 
-	if !c.resource.Matches(obj, c.cfg) || isExplicitlyDisabled(obj.GetAnnotations(), c.cfg.EnabledAnnotation) {
+	if !c.resource.Matches(obj, c.cfg) {
 		return c.removeEndpoint(endpointKey, namespace, name, "not-matched", flush)
 	}
 
 	probeURL := c.resource.URL(obj)
 	if probeURL == "" {
 		// Per-resync per-resource; common for headless Services.
-		slog.Debug("resource has no derivable URL",
-			"resource", c.Resource(), "namespace", namespace, "name", name)
+		c.log.Debug("resource has no derivable URL", "namespace", namespace, "name", name)
 		return c.removeEndpoint(endpointKey, namespace, name, "no-url", flush)
 	}
 
@@ -230,8 +229,7 @@ func (c *Controller) reconcile(ctx context.Context, key string, flush bool) erro
 		return fmt.Errorf("write after upsert: %w", err)
 	}
 	if changed {
-		slog.Info("updated endpoint",
-			"resource", c.Resource(), "namespace", namespace, "name", name, "url", e.URL)
+		c.log.Info("updated endpoint", "namespace", namespace, "name", name, "url", e.URL)
 	}
 	return nil
 }
@@ -255,8 +253,7 @@ func (c *Controller) removeEndpoint(key, namespace, name, reason string, flush b
 		return fmt.Errorf("write after delete: %w", err)
 	}
 	if removed {
-		slog.Info("removed endpoint",
-			"resource", c.Resource(), "namespace", namespace, "name", name, "reason", reason)
+		c.log.Info("removed endpoint", "namespace", namespace, "name", name, "reason", reason)
 	}
 	return nil
 }
@@ -280,16 +277,4 @@ func setURLPath(rawURL, path string) string {
 	}
 	u.Path = path
 	return u.String()
-}
-
-// isExplicitlyDisabled returns true only when the annotation is present *and*
-// falsy. Absence is not "disabled". Unparseable values (e.g. empty, "yes")
-// are treated as disabled so a typo can't silently widen monitoring.
-func isExplicitlyDisabled(annotations map[string]string, key string) bool {
-	v, ok := annotations[key]
-	if !ok {
-		return false
-	}
-	enabled, err := strconv.ParseBool(v)
-	return err != nil || !enabled
 }

--- a/internal/k8s/controller_test.go
+++ b/internal/k8s/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ type fakeResource struct {
 	conditions     []string
 	guardHost      string
 	urlFn          func(metav1.Object) string
+	matchesFn      func(metav1.Object, *config.Config) bool
 	parentAnnotsFn func(context.Context, metav1.Object, Fetcher) map[string]string
 }
 
@@ -35,7 +37,24 @@ func (f fakeResource) Prefix(*config.Config) string                             
 func (f fakeResource) DefaultConditions() []string                               { return f.conditions }
 func (f fakeResource) GuardHost(metav1.Object) string                            { return f.guardHost }
 func (fakeResource) Convert(u *unstructured.Unstructured) (metav1.Object, error) { return u, nil }
-func (fakeResource) Matches(metav1.Object, *config.Config) bool                  { return true }
+
+func (f fakeResource) Matches(obj metav1.Object, cfg *config.Config) bool {
+	if f.matchesFn != nil {
+		return f.matchesFn(obj, cfg)
+	}
+	return true
+}
+
+// matchesEnabledAnnotation rejects objects whose enabled annotation is falsy,
+// mirroring how real resources gate on the annotation inside Matches.
+func matchesEnabledAnnotation(obj metav1.Object, cfg *config.Config) bool {
+	v, ok := obj.GetAnnotations()[cfg.EnabledAnnotation]
+	if !ok {
+		return true
+	}
+	enabled, err := strconv.ParseBool(v)
+	return err == nil && enabled
+}
 
 func (f fakeResource) URL(obj metav1.Object) string {
 	if f.urlFn != nil {
@@ -136,11 +155,10 @@ func TestController_DisabledAnnotationRemovesEndpoint(t *testing.T) {
 		EnabledAnnotation:  "enabled",
 	}
 	writer := gatus.NewWriter(filepath.Join(t.TempDir(), "out.yaml"))
-	c := NewController(cfg, fakeResource{gvr: gvr}, writer, client)
+	// Mirror real resources: the enabled annotation gate lives in Matches.
+	c := NewController(cfg, fakeResource{gvr: gvr, matchesFn: matchesEnabledAnnotation}, writer, client)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+	ctx := t.Context()
 	go func() { _ = c.Run(ctx) }()
 	if !waitFor(t, func() bool { return writer.Len() == 1 }) {
 		t.Fatalf("expected 1 endpoint, got %d", writer.Len())
@@ -173,39 +191,16 @@ func TestController_MissingURLRemovesEndpoint(t *testing.T) {
 		urlFn: func(metav1.Object) string { return "" },
 	}, writer, client)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() { _ = c.Run(ctx) }()
-
-	// After sync the writer should still be empty - URL is empty so endpoint isn't added.
-	time.Sleep(500 * time.Millisecond)
+	// Drive reconcile directly off the indexer so the assertion is
+	// deterministic — an empty URL must never produce an endpoint.
+	if err := c.informer.GetIndexer().Add(makeUnstructured(gvr, nil)); err != nil {
+		t.Fatalf("seed indexer: %v", err)
+	}
+	if err := c.reconcile(context.Background(), "default/thing-a", true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
 	if writer.Len() != 0 {
 		t.Errorf("expected 0 endpoints when URL is empty, got %d", writer.Len())
-	}
-}
-
-func TestIsExplicitlyDisabled(t *testing.T) {
-	cases := []struct {
-		name string
-		ann  map[string]string
-		want bool
-	}{
-		{"absent", nil, false},
-		{"true", map[string]string{"enabled": "true"}, false},
-		{"True", map[string]string{"enabled": "True"}, false},
-		{"TRUE", map[string]string{"enabled": "TRUE"}, false},
-		{"one", map[string]string{"enabled": "1"}, false},
-		{"false", map[string]string{"enabled": "false"}, true},
-		{"zero", map[string]string{"enabled": "0"}, true},
-		{"empty", map[string]string{"enabled": ""}, true},
-		{"unparseable", map[string]string{"enabled": "yes"}, true},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isExplicitlyDisabled(tt.ann, "enabled"); got != tt.want {
-				t.Errorf("isExplicitlyDisabled() = %v, want %v", got, tt.want)
-			}
-		})
 	}
 }
 
@@ -261,8 +256,7 @@ func TestController_AppliesPrefixToEndpointName(t *testing.T) {
 		urlFn:  func(metav1.Object) string { return "https://x" },
 	}, writer, client)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	go func() { _ = c.Run(ctx) }()
 
 	if !waitFor(t, func() bool { return writer.Len() == 1 }) {
@@ -308,8 +302,7 @@ func TestController_TemplateInheritanceAndGuarded(t *testing.T) {
 	}
 	c := NewController(cfg, r, writer, client)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	go func() { _ = c.Run(ctx) }()
 
 	if !waitFor(t, func() bool { return writer.Len() == 1 }) {
@@ -371,8 +364,7 @@ func TestController_PathOverrideAndProbePathsFlag(t *testing.T) {
 			}
 			c := NewController(cfg, r, writer, client)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 			go func() { _ = c.Run(ctx) }()
 
 			if !waitFor(t, func() bool { return writer.Len() == 1 }) {

--- a/internal/resources/httproute.go
+++ b/internal/resources/httproute.go
@@ -30,7 +30,7 @@ type HTTPRoute struct{}
 
 func (HTTPRoute) GVR() schema.GroupVersionResource { return httpRouteGVR }
 
-func (HTTPRoute) Prefix(cfg *config.Config) string { return cfg.HTTPRoutePrefix }
+func (HTTPRoute) Prefix(cfg *config.Config) string { return cfg.Prefix(config.KindHTTPRoute) }
 
 func (HTTPRoute) Convert(u *unstructured.Unstructured) (metav1.Object, error) {
 	return convertTo[gatewayv1.HTTPRoute](u)
@@ -44,7 +44,7 @@ func (HTTPRoute) Matches(obj metav1.Object, cfg *config.Config) bool {
 	if len(cfg.GatewayNames) > 0 && !httpRouteReferencesAnyGateway(route, cfg.GatewayNames) {
 		return false
 	}
-	return matchesAnnotation(obj, cfg.AutoHTTPRoute, cfg)
+	return matchesAnnotation(obj, cfg.AutoEnabled(config.KindHTTPRoute), cfg)
 }
 
 func (HTTPRoute) URL(obj metav1.Object) string {

--- a/internal/resources/httproute_test.go
+++ b/internal/resources/httproute_test.go
@@ -26,6 +26,7 @@ func makeRoute(name string, hostnames []gatewayv1.Hostname, parentRefs []gateway
 }
 
 func TestHTTPRoute_URL(t *testing.T) {
+	t.Parallel()
 	exact := gatewayv1.PathMatchExact
 	prefix := gatewayv1.PathMatchPathPrefix
 	regex := gatewayv1.PathMatchRegularExpression
@@ -58,6 +59,7 @@ func TestHTTPRoute_URL(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := (HTTPRoute{}).URL(tt.in); got != tt.want {
 				t.Errorf("URL() = %q, want %q", got, tt.want)
 			}
@@ -66,6 +68,7 @@ func TestHTTPRoute_URL(t *testing.T) {
 }
 
 func TestHTTPRoute_Matches(t *testing.T) {
+	t.Parallel()
 	gw := gatewayv1.ObjectName("gw")
 	cases := []struct {
 		name string
@@ -76,31 +79,31 @@ func TestHTTPRoute_Matches(t *testing.T) {
 		{
 			name: "auto + no filter",
 			obj:  makeRoute("r", []gatewayv1.Hostname{"x"}, nil, nil),
-			cfg:  &config.Config{AutoHTTPRoute: true},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindHTTPRoute)},
 			want: true,
 		},
 		{
 			name: "gateway filter mismatch",
 			obj:  makeRoute("r", []gatewayv1.Hostname{"x"}, []gatewayv1.ParentReference{{Name: gw}}, nil),
-			cfg:  &config.Config{AutoHTTPRoute: true, GatewayNames: config.StringSet{"other"}},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindHTTPRoute), GatewayNames: config.StringSet{"other"}},
 			want: false,
 		},
 		{
 			name: "gateway filter match",
 			obj:  makeRoute("r", []gatewayv1.Hostname{"x"}, []gatewayv1.ParentReference{{Name: gw}}, nil),
-			cfg:  &config.Config{AutoHTTPRoute: true, GatewayNames: config.StringSet{"gw"}},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindHTTPRoute), GatewayNames: config.StringSet{"gw"}},
 			want: true,
 		},
 		{
 			name: "matches any of multiple gateway names",
 			obj:  makeRoute("r", []gatewayv1.Hostname{"x"}, []gatewayv1.ParentReference{{Name: gw}}, nil),
-			cfg:  &config.Config{AutoHTTPRoute: true, GatewayNames: config.StringSet{"other", "gw", "third"}},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindHTTPRoute), GatewayNames: config.StringSet{"other", "gw", "third"}},
 			want: true,
 		},
 		{
 			name: "rejects when none of multiple gateway names match",
 			obj:  makeRoute("r", []gatewayv1.Hostname{"x"}, []gatewayv1.ParentReference{{Name: gw}}, nil),
-			cfg:  &config.Config{AutoHTTPRoute: true, GatewayNames: config.StringSet{"a", "b"}},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindHTTPRoute), GatewayNames: config.StringSet{"a", "b"}},
 			want: false,
 		},
 		{
@@ -115,12 +118,13 @@ func TestHTTPRoute_Matches(t *testing.T) {
 		{
 			name: "non-route",
 			obj:  &corev1.Pod{},
-			cfg:  &config.Config{AutoHTTPRoute: true},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindHTTPRoute)},
 			want: false,
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := (HTTPRoute{}).Matches(tt.obj, tt.cfg); got != tt.want {
 				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
@@ -129,6 +133,7 @@ func TestHTTPRoute_Matches(t *testing.T) {
 }
 
 func TestHTTPRoute_DefaultConditionsAndGuardHost(t *testing.T) {
+	t.Parallel()
 	if got := (HTTPRoute{}).DefaultConditions(); len(got) != 1 || got[0] != "[STATUS] == 200" {
 		t.Errorf("DefaultConditions() = %v", got)
 	}
@@ -141,6 +146,7 @@ func TestHTTPRoute_DefaultConditionsAndGuardHost(t *testing.T) {
 }
 
 func TestHTTPRoute_ParentAnnotations(t *testing.T) {
+	t.Parallel()
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(gatewayGVR.GroupVersion().WithKind("Gateway"), &unstructured.Unstructured{})
 	scheme.AddKnownTypeWithName(gatewayGVR.GroupVersion().WithKind("GatewayList"), &unstructured.UnstructuredList{})
@@ -165,6 +171,7 @@ func TestHTTPRoute_ParentAnnotations(t *testing.T) {
 }
 
 func TestHTTPRoute_ParentAnnotations_NoParents(t *testing.T) {
+	t.Parallel()
 	scheme := runtime.NewScheme()
 	client := fake.NewSimpleDynamicClient(scheme)
 	route := makeRoute("r", []gatewayv1.Hostname{"x"}, nil, nil)
@@ -174,6 +181,7 @@ func TestHTTPRoute_ParentAnnotations_NoParents(t *testing.T) {
 }
 
 func TestHTTPRoute_ParentAnnotations_NonGatewayKind(t *testing.T) {
+	t.Parallel()
 	scheme := runtime.NewScheme()
 	client := fake.NewSimpleDynamicClient(scheme)
 	kind := gatewayv1.Kind("Service")

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -33,7 +33,7 @@ type Ingress struct{}
 
 func (Ingress) GVR() schema.GroupVersionResource { return ingressGVR }
 
-func (Ingress) Prefix(cfg *config.Config) string { return cfg.IngressPrefix }
+func (Ingress) Prefix(cfg *config.Config) string { return cfg.Prefix(config.KindIngress) }
 
 func (Ingress) Convert(u *unstructured.Unstructured) (metav1.Object, error) {
 	return convertTo[networkingv1.Ingress](u)
@@ -47,7 +47,7 @@ func (Ingress) Matches(obj metav1.Object, cfg *config.Config) bool {
 	if len(cfg.IngressClasses) > 0 && !cfg.IngressClasses.Contains(ingressClassOf(ing)) {
 		return false
 	}
-	return matchesAnnotation(obj, cfg.AutoIngress, cfg)
+	return matchesAnnotation(obj, cfg.AutoEnabled(config.KindIngress), cfg)
 }
 
 func (Ingress) URL(obj metav1.Object) string {

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -46,6 +46,7 @@ func makeIngressWithPaths(host string, tls bool, class *string, annotations map[
 }
 
 func TestIngress_URL(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		in   metav1.Object
@@ -85,6 +86,7 @@ func TestIngress_URL(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := (Ingress{}).URL(tt.in); got != tt.want {
 				t.Errorf("URL() = %q, want %q", got, tt.want)
 			}
@@ -93,9 +95,9 @@ func TestIngress_URL(t *testing.T) {
 }
 
 func TestIngress_Matches(t *testing.T) {
+	t.Parallel()
 	nginx := "nginx"
 	cfg := &config.Config{
-		AutoIngress:        false,
 		EnabledAnnotation:  config.DefaultEnabledAnnotation,
 		TemplateAnnotation: config.DefaultTemplateAnnotation,
 	}
@@ -109,7 +111,7 @@ func TestIngress_Matches(t *testing.T) {
 		{
 			name: "auto-mode allows anything",
 			obj:  makeIngress("x", false, nil, nil),
-			cfg:  &config.Config{AutoIngress: true, EnabledAnnotation: cfg.EnabledAnnotation, TemplateAnnotation: cfg.TemplateAnnotation},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindIngress), EnabledAnnotation: cfg.EnabledAnnotation, TemplateAnnotation: cfg.TemplateAnnotation},
 			want: true,
 		},
 		{
@@ -127,25 +129,25 @@ func TestIngress_Matches(t *testing.T) {
 		{
 			name: "ingress class mismatch rejects",
 			obj:  makeIngress("x", false, &nginx, map[string]string{cfg.EnabledAnnotation: "true"}),
-			cfg:  &config.Config{AutoIngress: true, IngressClasses: config.StringSet{"traefik"}},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindIngress), IngressClasses: config.StringSet{"traefik"}},
 			want: false,
 		},
 		{
 			name: "ingress class match accepts",
 			obj:  makeIngress("x", false, &nginx, nil),
-			cfg:  &config.Config{AutoIngress: true, IngressClasses: config.StringSet{"nginx"}},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindIngress), IngressClasses: config.StringSet{"nginx"}},
 			want: true,
 		},
 		{
 			name: "matches any of multiple ingress classes",
 			obj:  makeIngress("x", false, &nginx, nil),
-			cfg:  &config.Config{AutoIngress: true, IngressClasses: config.StringSet{"traefik", "nginx", "haproxy"}},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindIngress), IngressClasses: config.StringSet{"traefik", "nginx", "haproxy"}},
 			want: true,
 		},
 		{
 			name: "rejects when none of multiple ingress classes match",
 			obj:  makeIngress("x", false, &nginx, nil),
-			cfg:  &config.Config{AutoIngress: true, IngressClasses: config.StringSet{"traefik", "haproxy"}},
+			cfg:  &config.Config{Kinds: autoEnabled(config.KindIngress), IngressClasses: config.StringSet{"traefik", "haproxy"}},
 			want: false,
 		},
 		{
@@ -157,6 +159,7 @@ func TestIngress_Matches(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := (Ingress{}).Matches(tt.obj, tt.cfg); got != tt.want {
 				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
@@ -165,6 +168,7 @@ func TestIngress_Matches(t *testing.T) {
 }
 
 func TestIngress_DefaultConditions(t *testing.T) {
+	t.Parallel()
 	got := (Ingress{}).DefaultConditions()
 	if len(got) != 1 || got[0] != "[STATUS] == 200" {
 		t.Errorf("DefaultConditions() = %v", got)
@@ -172,6 +176,7 @@ func TestIngress_DefaultConditions(t *testing.T) {
 }
 
 func TestIngress_GuardHost(t *testing.T) {
+	t.Parallel()
 	if got := (Ingress{}).GuardHost(makeIngress("host.example.com", false, nil, nil)); got != "host.example.com" {
 		t.Errorf("GuardHost() = %q", got)
 	}
@@ -181,6 +186,7 @@ func TestIngress_GuardHost(t *testing.T) {
 }
 
 func TestIngressClassOf(t *testing.T) {
+	t.Parallel()
 	nginx := "nginx"
 	cases := []struct {
 		name string
@@ -198,6 +204,7 @@ func TestIngressClassOf(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := ingressClassOf(tt.ing); got != tt.want {
 				t.Errorf("ingressClassOf() = %q, want %q", got, tt.want)
 			}
@@ -206,6 +213,7 @@ func TestIngressClassOf(t *testing.T) {
 }
 
 func TestIngress_ParentAnnotations(t *testing.T) {
+	t.Parallel()
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(ingressClassGVR.GroupVersion().WithKind("IngressClass"), &unstructured.Unstructured{})
 	scheme.AddKnownTypeWithName(ingressClassGVR.GroupVersion().WithKind("IngressClassList"), &unstructured.UnstructuredList{})
@@ -229,6 +237,7 @@ func TestIngress_ParentAnnotations(t *testing.T) {
 }
 
 func TestIngress_ParentAnnotations_Missing(t *testing.T) {
+	t.Parallel()
 	scheme := runtime.NewScheme()
 	client := fake.NewSimpleDynamicClient(scheme)
 	ing := makeIngress("x", false, nil, nil)

--- a/internal/resources/ingressroute.go
+++ b/internal/resources/ingressroute.go
@@ -28,7 +28,7 @@ type IngressRoute struct{}
 
 func (IngressRoute) GVR() schema.GroupVersionResource { return ingressRouteGVR }
 
-func (IngressRoute) Prefix(cfg *config.Config) string { return cfg.IngressRoutePrefix }
+func (IngressRoute) Prefix(cfg *config.Config) string { return cfg.Prefix(config.KindIngressRoute) }
 
 func (IngressRoute) Convert(u *unstructured.Unstructured) (metav1.Object, error) {
 	return u, nil
@@ -38,7 +38,7 @@ func (IngressRoute) Matches(obj metav1.Object, cfg *config.Config) bool {
 	if _, ok := obj.(*unstructured.Unstructured); !ok {
 		return false
 	}
-	return matchesAnnotation(obj, cfg.AutoIngressRoute, cfg)
+	return matchesAnnotation(obj, cfg.AutoEnabled(config.KindIngressRoute), cfg)
 }
 
 func (IngressRoute) URL(obj metav1.Object) string {

--- a/internal/resources/ingressroute_test.go
+++ b/internal/resources/ingressroute_test.go
@@ -28,6 +28,7 @@ func makeIngressRouteWithMatch(match string, tls bool) *unstructured.Unstructure
 }
 
 func TestIngressRoute_URL(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		obj  metav1.Object
@@ -54,6 +55,7 @@ func TestIngressRoute_URL(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := (IngressRoute{}).URL(tt.obj); got != tt.want {
 				t.Errorf("URL() = %q, want %q", got, tt.want)
 			}
@@ -62,6 +64,7 @@ func TestIngressRoute_URL(t *testing.T) {
 }
 
 func TestIngressRoute_DefaultConditionsAndGuardHost(t *testing.T) {
+	t.Parallel()
 	if got := (IngressRoute{}).DefaultConditions(); len(got) != 1 || got[0] != "[STATUS] == 200" {
 		t.Errorf("DefaultConditions() = %v", got)
 	}
@@ -74,6 +77,7 @@ func TestIngressRoute_DefaultConditionsAndGuardHost(t *testing.T) {
 }
 
 func TestMatchTraefikHost(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		expr, want string
 	}{
@@ -85,6 +89,7 @@ func TestMatchTraefikHost(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.expr, func(t *testing.T) {
+			t.Parallel()
 			if got := matchTraefikHost(tt.expr); got != tt.want {
 				t.Errorf("matchTraefikHost(%q) = %q, want %q", tt.expr, got, tt.want)
 			}
@@ -93,6 +98,7 @@ func TestMatchTraefikHost(t *testing.T) {
 }
 
 func TestIngressRouteHasTLS(t *testing.T) {
+	t.Parallel()
 	u := &unstructured.Unstructured{Object: map[string]any{}}
 	if err := unstructured.SetNestedMap(u.Object, map[string]any{"secretName": "s"}, "spec", "tls"); err != nil {
 		t.Fatalf("SetNestedMap: %v", err)

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -5,6 +5,7 @@ package resources
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/home-operations/gatus-sidecar/internal/config"
@@ -39,30 +40,37 @@ func formatURL(host, path string, useTLS bool) string {
 }
 
 // matchesAnnotation accepts obj when auto-mode is on or when an explicit
-// gatus annotation opts the resource in. Callers run any kind-specific
-// filter (ingress class, gateway name) before this.
+// gatus annotation opts the resource in, unless the enabled annotation is
+// explicitly falsy. Callers run any kind-specific filter (ingress class,
+// gateway name) before this.
 func matchesAnnotation(obj metav1.Object, auto bool, cfg *config.Config) bool {
+	if isExplicitlyDisabled(obj.GetAnnotations(), cfg.EnabledAnnotation) {
+		return false
+	}
 	return auto || hasGatusAnnotations(obj, cfg)
 }
 
+// registry maps each kind name to its Resource constructor. It is the single
+// source of truth for which kinds exist and the order they're created in.
+var registry = []struct {
+	name string
+	new  func() k8s.Resource
+}{
+	{config.KindIngress, func() k8s.Resource { return Ingress{} }},
+	{config.KindHTTPRoute, func() k8s.Resource { return HTTPRoute{} }},
+	{config.KindService, func() k8s.Resource { return Service{} }},
+	{config.KindIngressRoute, func() k8s.Resource { return IngressRoute{} }},
+}
+
 // All returns the Resource implementations enabled by cfg. With no flag set,
-// all four kinds run in annotation-only mode.
+// all kinds run in annotation-only mode.
 func All(cfg *config.Config) []k8s.Resource {
-	if !cfg.AnyExplicitlyEnabled() {
-		return []k8s.Resource{Ingress{}, HTTPRoute{}, Service{}, IngressRoute{}}
-	}
-	out := make([]k8s.Resource, 0, 4)
-	if cfg.EnableIngress || cfg.AutoIngress {
-		out = append(out, Ingress{})
-	}
-	if cfg.EnableHTTPRoute || cfg.AutoHTTPRoute {
-		out = append(out, HTTPRoute{})
-	}
-	if cfg.EnableService || cfg.AutoService {
-		out = append(out, Service{})
-	}
-	if cfg.EnableIngressRoute || cfg.AutoIngressRoute {
-		out = append(out, IngressRoute{})
+	annotationOnly := !cfg.AnyExplicitlyEnabled()
+	out := make([]k8s.Resource, 0, len(registry))
+	for _, e := range registry {
+		if annotationOnly || cfg.KindEnabled(e.name) {
+			out = append(out, e.new())
+		}
 	}
 	return out
 }
@@ -88,4 +96,16 @@ func hasGatusAnnotations(obj metav1.Object, cfg *config.Config) bool {
 	}
 	_, ok := ann[cfg.TemplateAnnotation]
 	return ok
+}
+
+// isExplicitlyDisabled returns true only when the annotation is present *and*
+// falsy. Absence is not "disabled". Unparseable values (e.g. empty, "yes")
+// are treated as disabled so a typo can't silently widen monitoring.
+func isExplicitlyDisabled(annotations map[string]string, key string) bool {
+	v, ok := annotations[key]
+	if !ok {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	return err != nil || !enabled
 }

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -10,7 +10,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// autoEnabled returns a Kinds map with the named kind in auto-discovery mode.
+func autoEnabled(name string) map[string]*config.KindConfig {
+	return map[string]*config.KindConfig{name: {Auto: true}}
+}
+
 func TestAll_DefaultsToEverything(t *testing.T) {
+	t.Parallel()
 	got := All(&config.Config{})
 	if len(got) != 4 {
 		t.Errorf("got %d resources, want 4", len(got))
@@ -18,7 +24,10 @@ func TestAll_DefaultsToEverything(t *testing.T) {
 }
 
 func TestAll_HonorsExplicitFlags(t *testing.T) {
-	got := All(&config.Config{EnableIngress: true})
+	t.Parallel()
+	got := All(&config.Config{Kinds: map[string]*config.KindConfig{
+		config.KindIngress: {Enable: true},
+	}})
 	if len(got) != 1 {
 		t.Fatalf("got %d resources, want 1", len(got))
 	}
@@ -26,7 +35,10 @@ func TestAll_HonorsExplicitFlags(t *testing.T) {
 		t.Errorf("got %s, want ingresses", got[0].GVR().Resource)
 	}
 
-	got = All(&config.Config{AutoService: true, AutoHTTPRoute: true})
+	got = All(&config.Config{Kinds: map[string]*config.KindConfig{
+		config.KindService:   {Auto: true},
+		config.KindHTTPRoute: {Auto: true},
+	}})
 	names := map[string]bool{}
 	for _, r := range got {
 		names[r.GVR().Resource] = true
@@ -40,6 +52,7 @@ func TestAll_HonorsExplicitFlags(t *testing.T) {
 }
 
 func TestConvertTo(t *testing.T) {
+	t.Parallel()
 	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -58,12 +71,13 @@ func TestConvertTo(t *testing.T) {
 }
 
 func TestPrefix(t *testing.T) {
-	cfg := &config.Config{
-		IngressPrefix:      "ing-",
-		ServicePrefix:      "svc-",
-		HTTPRoutePrefix:    "route-",
-		IngressRoutePrefix: "traefik-",
-	}
+	t.Parallel()
+	cfg := &config.Config{Kinds: map[string]*config.KindConfig{
+		config.KindIngress:      {Prefix: "ing-"},
+		config.KindService:      {Prefix: "svc-"},
+		config.KindHTTPRoute:    {Prefix: "route-"},
+		config.KindIngressRoute: {Prefix: "traefik-"},
+	}}
 	cases := map[string]string{
 		"ing-":     Ingress{}.Prefix(cfg),
 		"svc-":     Service{}.Prefix(cfg),
@@ -78,6 +92,7 @@ func TestPrefix(t *testing.T) {
 }
 
 func TestHasGatusAnnotations(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{
 		EnabledAnnotation:  "enabled",
 		TemplateAnnotation: "tpl",
@@ -94,9 +109,37 @@ func TestHasGatusAnnotations(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			obj := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: tt.ann}}
 			if got := hasGatusAnnotations(obj, cfg); got != tt.want {
 				t.Errorf("hasGatusAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsExplicitlyDisabled(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ann  map[string]string
+		want bool
+	}{
+		{"absent", nil, false},
+		{"true", map[string]string{"enabled": "true"}, false},
+		{"True", map[string]string{"enabled": "True"}, false},
+		{"TRUE", map[string]string{"enabled": "TRUE"}, false},
+		{"one", map[string]string{"enabled": "1"}, false},
+		{"false", map[string]string{"enabled": "false"}, true},
+		{"zero", map[string]string{"enabled": "0"}, true},
+		{"empty", map[string]string{"enabled": ""}, true},
+		{"unparseable", map[string]string{"enabled": "yes"}, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isExplicitlyDisabled(tt.ann, "enabled"); got != tt.want {
+				t.Errorf("isExplicitlyDisabled() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -25,7 +25,7 @@ type Service struct{}
 
 func (Service) GVR() schema.GroupVersionResource { return serviceGVR }
 
-func (Service) Prefix(cfg *config.Config) string { return cfg.ServicePrefix }
+func (Service) Prefix(cfg *config.Config) string { return cfg.Prefix(config.KindService) }
 
 func (Service) Convert(u *unstructured.Unstructured) (metav1.Object, error) {
 	return convertTo[corev1.Service](u)
@@ -35,7 +35,7 @@ func (Service) Matches(obj metav1.Object, cfg *config.Config) bool {
 	if _, ok := obj.(*corev1.Service); !ok {
 		return false
 	}
-	return matchesAnnotation(obj, cfg.AutoService, cfg)
+	return matchesAnnotation(obj, cfg.AutoEnabled(config.KindService), cfg)
 }
 
 func (Service) URL(obj metav1.Object) string {

--- a/internal/resources/service_test.go
+++ b/internal/resources/service_test.go
@@ -20,6 +20,7 @@ func makeService(name, ns string, port int32, protocol corev1.Protocol) *corev1.
 }
 
 func TestService_URL(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		svc  metav1.Object
@@ -36,6 +37,7 @@ func TestService_URL(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := (Service{}).URL(tt.svc); got != tt.want {
 				t.Errorf("URL() = %q, want %q", got, tt.want)
 			}
@@ -44,11 +46,12 @@ func TestService_URL(t *testing.T) {
 }
 
 func TestService_DefaultConditionsAndMatches(t *testing.T) {
+	t.Parallel()
 	if got := (Service{}).DefaultConditions(); len(got) != 1 || got[0] != "[CONNECTED] == true" {
 		t.Errorf("DefaultConditions() = %v", got)
 	}
 
-	if !(Service{}).Matches(makeService("a", "n", 80, corev1.ProtocolTCP), &config.Config{AutoService: true}) {
+	if !(Service{}).Matches(makeService("a", "n", 80, corev1.ProtocolTCP), &config.Config{Kinds: autoEnabled(config.KindService)}) {
 		t.Error("auto mode should match")
 	}
 	if (Service{}).Matches(makeService("a", "n", 80, corev1.ProtocolTCP), &config.Config{EnabledAnnotation: "x", TemplateAnnotation: "y"}) {
@@ -57,6 +60,7 @@ func TestService_DefaultConditionsAndMatches(t *testing.T) {
 }
 
 func TestService_GuardHostAndParentAnnotations_NoOps(t *testing.T) {
+	t.Parallel()
 	if got := (Service{}).GuardHost(makeService("a", "n", 80, corev1.ProtocolTCP)); got != "" {
 		t.Errorf("GuardHost() = %q, want \"\"", got)
 	}


### PR DESCRIPTION
## Summary

A modernization/cleanliness pass. The codebase was already in good shape (0 lint/vet/deadcode/staticcheck issues, Go 1.26 idioms), so this focuses on the genuine wins rather than churn.

- **Data-driven kind registry.** Collapses the per-kind duplication across Ingress/HTTPRoute/Service/IngressRoute. `config.Config` now holds a `Kinds map[string]*KindConfig` driven by a metadata table for flag registration, with nil-safe accessors (`KindEnabled`/`AutoEnabled`/`Prefix`); `resources` selects implementations from a factory `registry`. **Flag names and `--help` text are unchanged.**
- **Consolidated annotation gate.** Moved `isExplicitlyDisabled` into `resources` and folded it into `matchesAnnotation`, removing the parallel check the controller used to run separately.
- **Scoped logging.** Each `Controller` gets a `slog.With("resource", …)` logger, so the ~8 log call sites drop the repeated `resource=` pair. Log output is byte-identical.
- **Tests/tooling.** `mise run test` now runs with `-race`; the missing-URL controller test is deterministic (drives `reconcile` directly instead of `time.Sleep`); pure unit tests are `t.Parallel()`; four defer-only controller tests use `t.Context()`.

No behavior change to the generated Gatus config — the refactor is structural.

### Deliberately *not* changed
- `+` string concat → `fmt.Sprintf` (would be slower, not a modernization)
- `reflect.DeepEqual` in `Writer.Upsert` (not a hot path; hand-rolled equality over `map[string]any` fields is a silent-drift risk)
- `testing/synctest` for controller tests (informer/workqueue goroutines run on the real clock, outside the bubble)
- removing `Writer.Len()` (test-only accessor; "unreachable from main" ≠ dead)

## Test plan
- [x] `gofmt -l` clean, `go vet ./...` clean
- [x] `golangci-lint run` → 0 issues
- [x] `staticcheck ./...` clean; `deadcode ./...` → only the intentional test-only `Writer.Len`
- [x] `go test -race ./...` passes (config 87%, gatus 89%, k8s 75%, resources 87%)
- [x] `--help` flag names + per-kind help text preserved (incl. "Traefik IngressRoute")
- [x] `go vet -tags e2e ./test/e2e/...` compiles
- [ ] e2e suite against a Kind cluster (not run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)