### PR TITLE
feat: add build version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ jobs:
       packages: write
     uses: docker/github-builder/.github/workflows/build.yml@17bd7d64200cae4ba58ffc099934e8012ae320f2 # v1.10.0
     with:
+      build-args: |
+        VERSION=${{ github.ref_name }}
+        REVISION=${{ github.sha }}
       meta-images: ghcr.io/${{ github.repository }}
       meta-tags: |
         type=semver,pattern={{version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.26-alpine AS builder
+ARG VERSION=dev
+ARG REVISION=dev
 WORKDIR /src
 RUN apk add --no-cache upx
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o /out/gatus-sidecar ./cmd/gatus-sidecar
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.Version=${VERSION} -X main.Gitsha=${REVISION}" -trimpath -o /out/gatus-sidecar ./cmd/gatus-sidecar
 RUN upx --best --lzma /out/gatus-sidecar
 
 FROM scratch

--- a/cmd/gatus-sidecar/main.go
+++ b/cmd/gatus-sidecar/main.go
@@ -20,6 +20,11 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
+var (
+	Version = "local"
+	Gitsha  = "?"
+)
+
 func main() {
 	if err := run(os.Args[0], os.Args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -36,6 +41,7 @@ func run(name string, args []string) error {
 		return err
 	}
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: cfg.LogLevel})))
+	slog.Info("starting gatus-sidecar", "version", Version, "gitsha", Gitsha)
 
 	enabled := resources.All(cfg)
 	if len(enabled) == 0 {


### PR DESCRIPTION
Part of standardizing build-version stamping across the org's Go services. gatus-sidecar was the only one with **no version variable at all**, so this adds it to match the others (`external-dns-unifi-webhook` is the reference).

- **cmd/gatus-sidecar/main.go**: add `main.Version`/`main.Gitsha` and log them once at startup (`slog.Info("starting gatus-sidecar", "version", …, "gitsha", …)`), identical to external-dns-unifi-webhook.
- **Dockerfile**: add `ARG VERSION`/`ARG REVISION`, inject via `-ldflags "-X main.Version=${VERSION} -X main.Gitsha=${REVISION}"`.
- **release.yaml**: pass `VERSION=${{ github.ref_name }}` and `REVISION=${{ github.sha }}`.

Verified locally that the ldflags reach both symbols (stamped a test value and confirmed it in the built binary).

> The `Release` workflow calls a reusable workflow, so it can't run on this PR — first exercised on the next push to `main` / release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
