### PR TITLE
ci: path-filter triggers, add concurrency, cache golangci-lint

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
@@ -35,6 +39,13 @@ jobs:
         with:
           experimental: true
           install_args: --locked
+
+      - name: Cache golangci-lint
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          restore-keys: ${{ runner.os }}-golangci-lint-
 
       - name: Run linter
         run: mise run lint

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded main builds (rolling tag); never interrupt a published release.
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   versions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded main builds (rolling tag); never interrupt a published release.
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What changed

CI workflow efficiency tweaks, mirroring the already-merged home-operations/kromgo#239:

**Path filters (`paths-ignore: ["**.md"]`)** — skip CI on Markdown-only changes:
- `tests.yaml` — under `push:` and `pull_request:`
- `lint.yaml` — under `push:` and `pull_request:`
- `e2e.yaml` — under `push:` and `pull_request:`
- `release.yaml` — under `push:` only (intentionally **not** under `release:`, since a published release should always build)

**Concurrency** — added where missing:
- `release.yaml` — cancels superseded `main` builds (rolling tag) but never interrupts a published release (`cancel-in-progress: ${{ github.event_name != 'release' }}`)
- `release-please.yaml` — serialized with `cancel-in-progress: false`

**golangci-lint cache** — `lint.yaml` runs `golangci-lint` via `mise run lint` (`.mise/config.toml` `[tasks.lint]` → `golangci-lint run`), so added a dedicated `actions/cache` step for `~/.cache/golangci-lint`, keyed on `go.sum` + `.golangci.yml`. Placed immediately after **Setup Mise** (this repo's lint job has no pre-existing `actions/cache` step).

## Skipped (with reasons)
- No `paths-ignore` added to any trigger that already had a `paths:` allow-list — none of the edited triggers have one, so nothing was skipped on this basis.
- `tests.yaml` / `lint.yaml` / `e2e.yaml` already have `concurrency:` blocks — left untouched.
- `release-please.yaml`, `renovate.yaml`, `stale.yaml` triggers left untouched per scope.

## Safety
Trigger/concurrency/cache-only changes. No required status checks are modified, renamed, or removed; job names and steps are unchanged (aside from the added cache step). Validated with `zizmor --offline` on all five changed workflows — no new findings.
