### PR TITLE
feat(chart): support Deployment annotations on the gatus-sidecar chart

### DIFF
--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -61,6 +61,7 @@ Kubernetes: `>=1.29.0-0`
 | affinity | object | `{}` | Affinity rules for pod scheduling. |
 | config.existingConfigMap | string | `""` | REQUIRED: name of a ConfigMap holding your gatus config file(s). |
 | config.items | list | `[]` | ConfigMap keys to mount read-only into gatus.configPath; each `{ key, path }` mounts the ConfigMap's `key` at `<configPath>/<path>` (subPath). |
+| deploymentAnnotations | object | `{}` | Annotations added to the Deployment (workload) metadata, e.g. `reloader.stakater.com/auto: "true"` so Stakater Reloader rolls the pod when the mounted config ConfigMap changes (Reloader reads the workload, not the pod). |
 | fullnameOverride | string | `""` | Override the full release name. |
 | gatus.configPath | string | `"/config"` | Directory gatus reads (GATUS_CONFIG_PATH). The shared volume is mounted here; the sidecar writes its generated YAML here and the BYO ConfigMap files are overlaid on top. The chart always sets GATUS_CONFIG_PATH to this. |
 | gatus.delayStartSeconds | string | `""` | Delay gatus startup by N seconds (GATUS_DELAY_START_SECONDS). Omitted when empty or 0. |
@@ -110,7 +111,7 @@ Kubernetes: `>=1.29.0-0`
 | persistence.existingClaim | string | `""` | Use an existing PVC instead of creating one; when set, no PVC is rendered. |
 | persistence.size | string | `"1Gi"` | PVC size. |
 | persistence.storageClass | string | `""` | StorageClass for the PVC; empty uses the cluster default. |
-| podAnnotations | object | `{}` | Annotations added to the pod (e.g. a config reloader annotation, since config is a BYO ConfigMap). |
+| podAnnotations | object | `{}` | Annotations added to the pod. |
 | podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. ⚠️ With a single replica, the default `minAvailable: 1` makes a node drain block until you delete the pod yourself; set `maxUnavailable: 1` instead to let drains proceed. Off by default. |
 | podDisruptionBudget.maxUnavailable | string | `""` | Maximum pods that may be unavailable, as a count or percentage; takes precedence over `minAvailable` when set. @schema type: [integer, string] @schema |
 | podDisruptionBudget.minAvailable | int | `1` | Minimum pods that must stay available, as a count or percentage. Used unless `maxUnavailable` is set. @schema type: [integer, string] @schema |

--- a/charts/gatus-sidecar/templates/deployment.tpl
+++ b/charts/gatus-sidecar/templates/deployment.tpl
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gatus-sidecar.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  # Workload-level annotations — e.g. a Stakater Reloader annotation, which must
+  # sit on the Deployment (not the pod) to roll it when the config ConfigMap changes.
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -172,6 +172,22 @@ tests:
           path: spec.template.spec.automountServiceAccountToken
           value: true
 
+  - it: omits Deployment annotations by default
+    template: deployment.tpl
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: renders deploymentAnnotations on the Deployment (e.g. a Reloader annotation)
+    template: deployment.tpl
+    set:
+      deploymentAnnotations:
+        reloader.stakater.com/auto: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+
   - it: sets the gatus env vars in order (CONFIG_PATH, WEB_PORT, then LOG_LEVEL)
     template: deployment.tpl
     set:

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -8,7 +8,7 @@
       "type": "object"
     },
     "config": {
-      "description": "Gatus configuration — supplied as an external ConfigMap; this chart never\nrenders config. Add a checksum/reloader annotation under `podAnnotations`\nyourself if you want pods to roll when the ConfigMap changes.",
+      "description": "Gatus configuration — supplied as an external ConfigMap; this chart never\nrenders config. Set a Reloader annotation under `deploymentAnnotations`\n(e.g. reloader.stakater.com/auto) if you want the pod to roll when the\nConfigMap changes.",
       "properties": {
         "existingConfigMap": {
           "default": "",
@@ -27,6 +27,12 @@
       },
       "required": [],
       "title": "config",
+      "type": "object"
+    },
+    "deploymentAnnotations": {
+      "description": "Annotations added to the Deployment (workload) metadata, e.g. `reloader.stakater.com/auto: \"true\"` so Stakater Reloader rolls the pod when the mounted config ConfigMap changes (Reloader reads the workload, not the pod).",
+      "required": [],
+      "title": "deploymentAnnotations",
       "type": "object"
     },
     "fullnameOverride": {
@@ -557,7 +563,7 @@
       "type": "object"
     },
     "podAnnotations": {
-      "description": "Annotations added to the pod (e.g. a config reloader annotation, since config is a BYO ConfigMap).",
+      "description": "Annotations added to the pod.",
       "required": [],
       "title": "podAnnotations",
       "type": "object"

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -151,8 +151,9 @@ sidecar:
         - ALL
 
 # Gatus configuration — supplied as an external ConfigMap; this chart never
-# renders config. Add a checksum/reloader annotation under `podAnnotations`
-# yourself if you want pods to roll when the ConfigMap changes.
+# renders config. Set a Reloader annotation under `deploymentAnnotations`
+# (e.g. reloader.stakater.com/auto) if you want the pod to roll when the
+# ConfigMap changes.
 config:
   # -- REQUIRED: name of a ConfigMap holding your gatus config file(s).
   existingConfigMap: ""
@@ -203,7 +204,9 @@ nameOverride: ""
 # -- Override the full release name.
 fullnameOverride: ""
 
-# -- Annotations added to the pod (e.g. a config reloader annotation, since config is a BYO ConfigMap).
+# -- Annotations added to the Deployment (workload) metadata, e.g. `reloader.stakater.com/auto: "true"` so Stakater Reloader rolls the pod when the mounted config ConfigMap changes (Reloader reads the workload, not the pod).
+deploymentAnnotations: {}
+# -- Annotations added to the pod.
 podAnnotations: {}
 # -- Labels added to the pod.
 podLabels: {}


### PR DESCRIPTION
Follow-up to #79 (the `gatus-sidecar` chart, merged + released as `0.2.1`).

Adds **`deploymentAnnotations`**, rendered into the **Deployment** `metadata.annotations`, so a Stakater **Reloader** annotation can roll the pod when the mounted config ConfigMap changes:

```yaml
deploymentAnnotations:
  reloader.stakater.com/auto: "true"
```

Reloader reads the **workload** (Deployment), not the pod template, so the existing `podAnnotations` couldn't do this. This PR also fixes two `values.yaml` comments that wrongly pointed Reloader at `podAnnotations`.

Values are `tpl`-rendered (so you can template them). helm lint / template / **helm-unittest (44/44)** / generate-check all green.
