### PR TITLE
feat(chart)!: use a single pod-level resources key (Pod.spec.resources)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -79,13 +79,15 @@ jobs:
           experimental: true
           install_args: --locked
 
-      # Native sidecars (initContainer restartPolicy: Always) are stable from
-      # 1.29; pin a node image well past that so the gatus-sidecar starts.
+      # The chart requires Kubernetes 1.34+ (pod-level resources), so pin a 1.34
+      # node image: `helm install` must satisfy the chart's kubeVersion, and 1.34
+      # is where PodLevelResources is beta/on by default. kind ships 1.34 node
+      # images from v0.30.0, so bump the kind binary too.
       - name: Create Kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
-          version: v0.27.0
-          node_image: kindest/node:v1.31.6
+          version: v0.30.0
+          node_image: kindest/node:v1.34.0
           cluster_name: gatus-sidecar-helm-e2e
           wait: 60s
 

--- a/charts/gatus-sidecar/Chart.yaml
+++ b/charts/gatus-sidecar/Chart.yaml
@@ -3,9 +3,10 @@ apiVersion: v2
 name: gatus-sidecar
 description: Deploy Gatus with the home-operations gatus-sidecar for automatic endpoint discovery
 type: application
-# Native sidecars (restartPolicy: Always init containers) are stable from 1.29,
-# and the Gateway API v1 HTTPRoute is GA there too.
-kubeVersion: ">=1.29.0-0"
+# Pod-level resources (Pod.spec.resources) are beta and on by default from 1.34,
+# so the chart's top-level `resources` works without enabling a feature gate.
+# (Native sidecars are stable from 1.29 and Gateway API v1 HTTPRoute is GA there.)
+kubeVersion: ">=1.34.0-0"
 # version + appVersion are overridden at package time: version from the release
 # tag (the gatus-sidecar repo's own version), appVersion from the pinned gatus
 # image tag.

--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -59,7 +59,7 @@ Kubernetes: `>=1.29.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for pod scheduling. |
-| config.existingConfigMap | string | `""` | REQUIRED: name of a ConfigMap holding your gatus config file(s). |
+| config.existingConfigMap | string | `""` | REQUIRED: name of a ConfigMap holding your gatus config file(s) (templated, so a release-derived name works). |
 | config.items | list | `[]` | ConfigMap keys to mount read-only into gatus.configPath; each `{ key, path }` mounts the ConfigMap's `key` at `<configPath>/<path>` (subPath). |
 | deploymentAnnotations | object | `{}` | Annotations added to the Deployment (workload) metadata, e.g. `reloader.stakater.com/auto: "true"` so Stakater Reloader rolls the pod when the mounted config ConfigMap changes (Reloader reads the workload, not the pod). |
 | fullnameOverride | string | `""` | Override the full release name. |

--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -52,7 +52,7 @@ either `ingress` or a Gateway API `httpRoute`.
 
 ## Requirements
 
-Kubernetes: `>=1.29.0-0`
+Kubernetes: `>=1.34.0-0`
 
 ## Values
 
@@ -121,7 +121,7 @@ Kubernetes: `>=1.29.0-0`
 | rbac.extraRules | list | `[]` | Extra policy rules appended to the derived rules. The base rules are generated from the enabled `sidecar.kinds` (least privilege, get/list/watch), so you normally leave this empty. |
 | rbac.type | string | `"ClusterRole"` | RBAC scope: ClusterRole (watch all namespaces) or Role (single namespace; pair with the sidecar's `namespace`). |
 | replicaCount | int | `1` | Number of gatus replicas. Gatus is backed by a Deployment; with persistence enabled (a single RWO PVC) keep this at 1. |
-| resources | object | `{}` | Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Requires Kubernetes 1.34+ (PodLevelResources is beta, on by default), or 1.32–1.33 with the `PodLevelResources` feature gate enabled; older clusters silently ignore it. Empty leaves it unset. |
+| resources | object | `{}` | Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Needs Kubernetes 1.34+, where PodLevelResources is beta and on by default; the chart's kubeVersion enforces this. Empty leaves it unset. |
 | service.port | int | `80` | Service port (maps to the gatus web port; /metrics is served here too). |
 | service.type | string | `"ClusterIP"` | Service type. |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount. |

--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -76,7 +76,6 @@ Kubernetes: `>=1.29.0-0`
 | gatus.logLevel | string | `"INFO"` | Gatus log level (GATUS_LOG_LEVEL: DEBUG, INFO, WARN, ERROR). Omitted when empty. |
 | gatus.port | int | `8080` | Container port, Service targetPort and probe port. Also exported as GATUS_WEB_PORT so your config can use `web.port: ${GATUS_WEB_PORT}`; gatus's actual listen port comes from its config file, so reference this var or match it. |
 | gatus.readinessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Gatus readiness probe. |
-| gatus.resources | object | `{}` | Gatus container resource requests/limits. |
 | gatus.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Gatus container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities). |
 | gatus.startupProbe | object | `{}` | Gatus startup probe (optional). Gates liveness/readiness while gatus starts; empty disables it. |
 | httpRoute.additionalRules | list | `[]` | Custom rules prepended before the default rule (templated). |
@@ -122,6 +121,7 @@ Kubernetes: `>=1.29.0-0`
 | rbac.extraRules | list | `[]` | Extra policy rules appended to the derived rules. The base rules are generated from the enabled `sidecar.kinds` (least privilege, get/list/watch), so you normally leave this empty. |
 | rbac.type | string | `"ClusterRole"` | RBAC scope: ClusterRole (watch all namespaces) or Role (single namespace; pair with the sidecar's `namespace`). |
 | replicaCount | int | `1` | Number of gatus replicas. Gatus is backed by a Deployment; with persistence enabled (a single RWO PVC) keep this at 1. |
+| resources | object | `{}` | Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Requires Kubernetes 1.34+ (PodLevelResources is beta, on by default), or 1.32–1.33 with the `PodLevelResources` feature gate enabled; older clusters silently ignore it. Empty leaves it unset. |
 | service.port | int | `80` | Service port (maps to the gatus web port; /metrics is served here too). |
 | service.type | string | `"ClusterIP"` | Service type. |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount. |
@@ -145,7 +145,6 @@ Kubernetes: `>=1.29.0-0`
 | sidecar.namespace | string | `""` | Namespace to watch (--namespace); empty watches all namespaces (requires a ClusterRole). |
 | sidecar.output | string | `""` | File the sidecar writes generated YAML to (--output); empty defaults to `<gatus.configPath>/gatus-sidecar.yaml` (in the shared volume). |
 | sidecar.probePaths | bool | `true` | Include paths from match rules in probe URLs (--probe-paths); false probes bare hostnames. |
-| sidecar.resources | object | `{}` | gatus-sidecar container resource requests/limits. |
 | sidecar.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | gatus-sidecar container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities). |
 | terminationGracePeriodSeconds | int | `30` | Grace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM). |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |

--- a/charts/gatus-sidecar/templates/_helpers.tpl
+++ b/charts/gatus-sidecar/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Name of the ConfigMap holding the gatus config files. This is required — the
 chart does not render config — so callers must set config.existingConfigMap.
 */}}
 {{- define "gatus-sidecar.configMapName" -}}
-{{- required "config.existingConfigMap is required: provide a ConfigMap with your gatus config files" .Values.config.existingConfigMap -}}
+{{- tpl (required "config.existingConfigMap is required: provide a ConfigMap with your gatus config files" .Values.config.existingConfigMap) $ -}}
 {{- end }}
 
 {{/*

--- a/charts/gatus-sidecar/templates/deployment.tpl
+++ b/charts/gatus-sidecar/templates/deployment.tpl
@@ -42,8 +42,8 @@ spec:
         {{- tpl (toYaml .Values.podSecurityContext) $ | nindent 8 }}
       {{- with .Values.resources }}
       # Pod-level resources (Pod.spec.resources) — one budget shared by the gatus
-      # and sidecar containers. Needs Kubernetes 1.34+ (PodLevelResources beta) or
-      # 1.32–1.33 with the feature gate; older clusters silently ignore it.
+      # and sidecar containers. Needs Kubernetes 1.34+ (PodLevelResources beta, on
+      # by default); the chart's kubeVersion enforces this.
       resources:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/charts/gatus-sidecar/templates/deployment.tpl
+++ b/charts/gatus-sidecar/templates/deployment.tpl
@@ -40,6 +40,13 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- tpl (toYaml .Values.podSecurityContext) $ | nindent 8 }}
+      {{- with .Values.resources }}
+      # Pod-level resources (Pod.spec.resources) — one budget shared by the gatus
+      # and sidecar containers. Needs Kubernetes 1.34+ (PodLevelResources beta) or
+      # 1.32–1.33 with the feature gate; older clusters silently ignore it.
+      resources:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- if .Values.sidecar.enabled }}
       # Native sidecar: an init container with restartPolicy: Always runs for the
       # life of the pod, starting before — and stopping after — the gatus container.
@@ -60,10 +67,6 @@ spec:
           {{- end }}
           securityContext:
             {{- tpl (toYaml .Values.sidecar.securityContext) $ | nindent 12 }}
-          {{- with .Values.sidecar.resources }}
-          resources:
-            {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.gatus.configPath }}
@@ -115,10 +118,6 @@ spec:
           {{- end }}
           {{- with .Values.gatus.readinessProbe }}
           readinessProbe:
-            {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
-          {{- with .Values.gatus.resources }}
-          resources:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -402,3 +402,17 @@ tests:
           path: spec.template.spec.containers[0].resources
       - notExists:
           path: spec.template.spec.initContainers[0].resources
+
+  - it: renders config.existingConfigMap through tpl
+    template: deployment.tpl
+    release:
+      name: prod
+    set:
+      config.existingConfigMap: "{{ .Release.Name }}-cfg"
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: config-files
+      - equal:
+          path: spec.template.spec.volumes[0].configMap.name
+          value: prod-cfg

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -370,3 +370,35 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 30
+
+  - it: omits pod-level resources by default and never sets them per-container
+    template: deployment.tpl
+    asserts:
+      - notExists:
+          path: spec.template.spec.resources
+      - notExists:
+          path: spec.template.spec.containers[0].resources
+      - notExists:
+          path: spec.template.spec.initContainers[0].resources
+
+  - it: sets pod-level resources (Pod.spec.resources) shared across containers when configured
+    template: deployment.tpl
+    set:
+      resources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 50m
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.resources.limits.memory
+          value: 256Mi
+      - equal:
+          path: spec.template.spec.resources.requests.cpu
+          value: 50m
+      # pod-level only — the budget is not duplicated onto the gatus/sidecar containers
+      - notExists:
+          path: spec.template.spec.containers[0].resources
+      - notExists:
+          path: spec.template.spec.initContainers[0].resources

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -12,7 +12,7 @@
       "properties": {
         "existingConfigMap": {
           "default": "",
-          "description": "REQUIRED: name of a ConfigMap holding your gatus config file(s).",
+          "description": "REQUIRED: name of a ConfigMap holding your gatus config file(s) (templated, so a release-derived name works).",
           "title": "existingConfigMap",
           "type": "string"
         },

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -675,7 +675,7 @@
       "type": "integer"
     },
     "resources": {
-      "description": "Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Requires Kubernetes 1.34+ (PodLevelResources is beta, on by default), or 1.32–1.33 with the `PodLevelResources` feature gate enabled; older clusters silently ignore it. Empty leaves it unset.",
+      "description": "Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Needs Kubernetes 1.34+, where PodLevelResources is beta and on by default; the chart's kubeVersion enforces this. Empty leaves it unset.",
       "required": [],
       "title": "resources",
       "type": "object"

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -191,14 +191,8 @@
           "title": "readinessProbe",
           "type": "object"
         },
-        "resources": {
-          "description": "  - secretRef:\n      name: gatus-secrets\nGatus container resource requests/limits.",
-          "required": [],
-          "title": "resources",
-          "type": "object"
-        },
         "securityContext": {
-          "description": "  limits:\n    memory: 256Mi\n  requests:\n    cpu: 10m\n    memory: 64Mi\nGatus container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).",
+          "description": "  - secretRef:\n      name: gatus-secrets\nGatus container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).",
           "properties": {
             "allowPrivilegeEscalation": {
               "default": false,
@@ -680,6 +674,12 @@
       "title": "replicaCount",
       "type": "integer"
     },
+    "resources": {
+      "description": "Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Requires Kubernetes 1.34+ (PodLevelResources is beta, on by default), or 1.32–1.33 with the `PodLevelResources` feature gate enabled; older clusters silently ignore it. Empty leaves it unset.",
+      "required": [],
+      "title": "resources",
+      "type": "object"
+    },
     "service": {
       "properties": {
         "port": {
@@ -939,12 +939,6 @@
           "description": "Include paths from match rules in probe URLs (--probe-paths); false probes bare hostnames.",
           "title": "probePaths",
           "type": "boolean"
-        },
-        "resources": {
-          "description": "gatus-sidecar container resource requests/limits.",
-          "required": [],
-          "title": "resources",
-          "type": "object"
         },
         "securityContext": {
           "description": "gatus-sidecar container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).",

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -210,7 +210,7 @@ podSecurityContext:
   fsGroup: 1000
   fsGroupChangePolicy: OnRootMismatch
 
-# -- Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Requires Kubernetes 1.34+ (PodLevelResources is beta, on by default), or 1.32–1.33 with the `PodLevelResources` feature gate enabled; older clusters silently ignore it. Empty leaves it unset.
+# -- Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Needs Kubernetes 1.34+, where PodLevelResources is beta and on by default; the chart's kubeVersion enforces this. Empty leaves it unset.
 resources: {}
 #   limits:
 #     memory: 256Mi

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -146,7 +146,7 @@ sidecar:
 # (e.g. reloader.stakater.com/auto) if you want the pod to roll when the
 # ConfigMap changes.
 config:
-  # -- REQUIRED: name of a ConfigMap holding your gatus config file(s).
+  # -- REQUIRED: name of a ConfigMap holding your gatus config file(s) (templated, so a release-derived name works).
   existingConfigMap: ""
   # -- ConfigMap keys to mount read-only into gatus.configPath; each `{ key, path }` mounts the ConfigMap's `key` at `<configPath>/<path>` (subPath).
   items: []

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -50,13 +50,6 @@ gatus:
   envFrom: []
   #   - secretRef:
   #       name: gatus-secrets
-  # -- Gatus container resource requests/limits.
-  resources: {}
-  #   limits:
-  #     memory: 256Mi
-  #   requests:
-  #     cpu: 10m
-  #     memory: 64Mi
   # -- Gatus container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).
   securityContext:
     allowPrivilegeEscalation: false
@@ -140,8 +133,6 @@ sidecar:
   extraArgs: []
   # -- Extra environment variables for the sidecar container, as a raw list (templated).
   extraEnv: []
-  # -- gatus-sidecar container resource requests/limits.
-  resources: {}
   # -- gatus-sidecar container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).
   securityContext:
     allowPrivilegeEscalation: false
@@ -218,6 +209,14 @@ podSecurityContext:
   runAsGroup: 1000
   fsGroup: 1000
   fsGroupChangePolicy: OnRootMismatch
+
+# -- Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Requires Kubernetes 1.34+ (PodLevelResources is beta, on by default), or 1.32–1.33 with the `PodLevelResources` feature gate enabled; older clusters silently ignore it. Empty leaves it unset.
+resources: {}
+#   limits:
+#     memory: 256Mi
+#   requests:
+#     cpu: 50m
+#     memory: 128Mi
 
 service:
   # -- Service type.


### PR DESCRIPTION
## What

Replace the two per-container resource keys — `gatus.resources` and `sidecar.resources` — with a single **top-level `resources`** that maps to the Kubernetes pod-level resources field (`Pod.spec.resources`).

## Why

This chart is a multi-container pod: the `gatus` container plus the `gatus-sidecar` native sidecar (an init container with `restartPolicy: Always`). Pod-level resources let you set **one budget shared across both containers** instead of splitting requests/limits per container and guessing the split. That's the natural model here now that Kubernetes supports it.

## Behavior

- Rendered at the pod spec level, only when set (`{{- with .Values.resources }}`), so the default (`{}`) leaves the field unset.
- **Not** duplicated onto the containers — the gatus and sidecar containers no longer carry their own `resources` blocks.

```yaml
# values.yaml
resources:
  limits:
    memory: 256Mi
  requests:
    cpu: 50m
    memory: 128Mi
```

renders as:

```yaml
spec:
  template:
    spec:
      resources:        # <- pod level
        limits: { memory: 256Mi }
        requests: { cpu: 50m, memory: 128Mi }
      initContainers:
        - name: gatus-sidecar   # no resources block
      containers:
        - name: gatus           # no resources block
```

## Compatibility

The chart now **requires Kubernetes 1.34+** — `kubeVersion` is raised to `>=1.34.0-0`. That's where `PodLevelResources` is beta and on by default, so the top-level `resources` works without a feature gate, and Helm refuses to install on 1.29–1.33 rather than silently dropping the field.

The **Helm e2e** kind cluster moves to a 1.34 node image (`kindest/node:v1.34.0`, which needs the kind binary at `v0.30.0+`) so `helm install` satisfies the new constraint and actually exercises pod-level resources. The Go-binary e2e job is left unchanged — it tests the sidecar against the API server, not the chart, so it isn't gated by `kubeVersion`.

## Migration (breaking)

This release requires **Kubernetes 1.34+**. And if you set either per-container `resources` key, move the values up to the top level:

```diff
-gatus:
-  resources:
-    requests: { cpu: 10m, memory: 64Mi }
-sidecar:
-  resources:
-    requests: { cpu: 10m, memory: 32Mi }
+resources:
+  requests: { cpu: 50m, memory: 128Mi }   # one shared pod budget
```

release-please will cut **0.3.0** (breaking change, `bump-minor-pre-major`).

## Verification

- `helm lint` — pass
- `helm unittest` — **47 passed** (added: pod-level resources rendered when set; omitted by default and never set per-container)
- `helm template` — confirmed `resources` renders at pod level with neither container carrying its own block
- `kubeVersion` enforced — `helm template --kube-version 1.33.0` fails (`chart requires kubeVersion: >=1.34.0-0 which is incompatible with Kubernetes v1.33.0`); `1.34.0` renders
- README + `values.schema.json` regenerated (`mise run generate`); the `gatus.resources`/`sidecar.resources` rows are gone, a single top-level `resources` row/property is present, and the README requirements line now reads `Kubernetes: >=1.34.0-0`

---

## Also in this PR — `config.existingConfigMap` is now templated

`config.existingConfigMap` is rendered through `tpl`, so the ConfigMap name can be a template expression (e.g. a release-derived `{{ .Release.Name }}-config`), matching the rest of the chart's tpl-rendered values. The `required` guard is preserved, so an unset value still errors clearly. Non-breaking; a plain string name behaves exactly as before. Covered by a new unittest (47 total) and confirmed by `helm template`.
