### PR TITLE
chore(chart): use the shared curl image for the helm test pod

### DIFF
--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -148,8 +148,8 @@ Kubernetes: `>=1.34.0-0`
 | sidecar.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | gatus-sidecar container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities). |
 | terminationGracePeriodSeconds | int | `30` | Grace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM). |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |
-| tests.image.repository | string | `"ghcr.io/home-operations/busybox"` | `helm test` pod image; needs a shell with wget (gatus's own image lacks one). |
-| tests.image.tag | string | `"1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |
+| tests.image.repository | string | `"mirror.gcr.io/curlimages/curl"` | `helm test` connection-pod image; a gcr-mirrored curl, so the test never pulls from Docker Hub. |
+| tests.image.tag | string | `"8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |
 | tolerations | list | `[]` | Tolerations for pod scheduling. |
 | volumeMounts | list | `[]` | Additional volume mounts on the gatus container. |
 | volumes | list | `[]` | Additional volumes on the Deployment pod. |

--- a/charts/gatus-sidecar/templates/tests/test-connection.tpl
+++ b/charts/gatus-sidecar/templates/tests/test-connection.tpl
@@ -30,12 +30,12 @@ spec:
         capabilities:
           drop:
             - ALL
-      # Gatus serves /health on the web port; this checks that the Service routes
-      # to a running, listening pod. wget writes to stdout (-O-) so the rootfs stays
-      # read-only; a non-2xx or refused connection exits non-zero and fails the test.
+      # Gatus serves /health on the web port; this checks that the Service routes to a
+      # running, listening pod. curl -f fails on a non-2xx (or a refused connection),
+      # failing the test; -sS stays quiet but still surfaces errors, and the body goes
+      # to stdout (no file write, so the rootfs stays read-only).
       command:
-        - wget
+        - curl
       args:
-        - -q
-        - -O-
+        - -fsS
         - http://{{ include "gatus-sidecar.fullname" . }}:{{ .Values.service.port }}/health

--- a/charts/gatus-sidecar/tests/test-connection_test.yaml
+++ b/charts/gatus-sidecar/tests/test-connection_test.yaml
@@ -2,7 +2,7 @@ suite: test-connection
 templates:
   - tests/test-connection.tpl
 tests:
-  - it: is a hardened helm test Pod that probes /health with the tag+digest-pinned busybox
+  - it: is a hardened helm test Pod that probes /health with the tag+digest-pinned curl
     asserts:
       - isKind:
           of: Pod
@@ -11,7 +11,7 @@ tests:
           value: test
       - matchRegex:
           path: spec.containers[0].image
-          pattern: busybox:.+@sha256:[0-9a-f]{64}$
+          pattern: curlimages/curl:.+@sha256:[0-9a-f]{64}$
       - equal:
           path: spec.securityContext.runAsNonRoot
           value: true

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -1000,13 +1000,13 @@
               "type": "string"
             },
             "repository": {
-              "default": "ghcr.io/home-operations/busybox",
-              "description": "`helm test` pod image; needs a shell with wget (gatus's own image lacks one).",
+              "default": "mirror.gcr.io/curlimages/curl",
+              "description": "`helm test` connection-pod image; a gcr-mirrored curl, so the test never pulls from Docker Hub.",
               "title": "repository",
               "type": "string"
             },
             "tag": {
-              "default": "1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df",
+              "default": "8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a",
               "description": "`helm test` image, pinned as `tag",
               "title": "tag",
               "type": "string"

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -332,9 +332,9 @@ volumeMounts: []
 # Config for the chart's `helm test` hook (a pod that curls the Service's /health). Used only by `helm test`, never the workload.
 tests:
   image:
-    # -- `helm test` pod image; needs a shell with wget (gatus's own image lacks one).
-    repository: ghcr.io/home-operations/busybox
+    # -- `helm test` connection-pod image; a gcr-mirrored curl, so the test never pulls from Docker Hub.
+    repository: mirror.gcr.io/curlimages/curl
     # -- `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together.
-    tag: "1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df"
+    tag: "8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a"
     # -- `helm test` image pull policy.
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Standardizes the `helm test` connection pod on the same curl image the **echo** chart already uses — `mirror.gcr.io/curlimages/curl` (gcr-mirrored, so the test never pulls from Docker Hub) — instead of `ghcr.io/home-operations/busybox`. One image across the home-ops charts instead of two.

## Change

- `values.yaml` — `tests.image` → `mirror.gcr.io/curlimages/curl` at the same tag+digest echo pins (`8.20.0@sha256:b3f1…812a`).
- `templates/tests/test-connection.tpl` — probe switches from busybox `wget -q -O-` to `curl -fsS` (the curl image has no `wget`). `-f` fails the test on a non-2xx or refused connection, like wget did; the body still goes to stdout so the rootfs stays read-only. Same `/health` target on the web port, same hardened securityContext.
- Regenerated `values.schema.json` + `README.md`; helm-unittest image-pattern assertion updated to `curlimages/curl`.

No functional change — the test pod runs only during `helm test`, never the workload. Renovate tracks the new image via the same helm-values manager (no config change needed).

## Verify

- helm-unittest 47/47; helm-lint 0 failed; generate-check in sync
- `helm template` renders the pod with the curl image and `curl -fsS http://…:80/health`
- The kind Helm E2E job exercises the pod live