### PR TITLE
build: standardize the image on distroless/static:nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.Version=${VERSION} -X main.Gitsha=${REVISION}" -trimpath -o /out/gatus-sidecar ./cmd/gatus-sidecar
 RUN upx --best --lzma /out/gatus-sidecar
 
-FROM scratch
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /out/gatus-sidecar /gatus-sidecar
 ENTRYPOINT ["/gatus-sidecar"]


### PR DESCRIPTION
Standardizes the **gatus-sidecar image** on the fleet base: runtime → `gcr.io/distroless/static:nonroot` (was `scratch`), from the existing `golang-alpine` + `upx` builder. The static binary runs identically, and distroless/static bundles CA certs + a nonroot user.

**Chart `podSecurityContext` intentionally left at uid 1000** (not moved to 65532 like the other charts): this pod also runs the upstream `ghcr.io/twin/gatus` container, which shares the pod securityContext and expects 1000. Our sidecar (a static binary) runs fine at 1000, so the image change is safe; forcing 65532 would risk the gatus container. Flagged for a separate decision.
