### PR TITLE
fix(chart): align pod securityContext to uid/gid/fsGroup 65532

### DIFF
--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -115,7 +115,7 @@ Kubernetes: `>=1.34.0-0`
 | podDisruptionBudget.maxUnavailable | string | `""` | Maximum pods that may be unavailable, as a count or percentage; takes precedence over `minAvailable` when set. @schema type: [integer, string] @schema |
 | podDisruptionBudget.minAvailable | int | `1` | Minimum pods that must stay available, as a count or percentage. Used unless `maxUnavailable` is set. @schema type: [integer, string] @schema |
 | podLabels | object | `{}` | Labels added to the pod. |
-| podSecurityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Pod-level securityContext (runs as non-root uid/gid 1000 with fsGroup so the shared /config volume is writable). |
+| podSecurityContext | object | `{"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | Pod-level securityContext (runs as non-root uid/gid 65532 with fsGroup so the shared /config volume is writable). |
 | priorityClassName | string | `""` | PriorityClass for the pod, so gatus is less likely to be preempted/evicted under node pressure. Empty uses the cluster default. |
 | rbac.create | bool | `true` | Create RBAC (a (Cluster)Role + binding) granting the sidecar the access it needs. |
 | rbac.extraRules | list | `[]` | Extra policy rules appended to the derived rules. The base rules are generated from the enabled `sidecar.kinds` (least privilege, get/list/watch), so you normally leave this empty. |

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -603,10 +603,10 @@
       "type": "object"
     },
     "podSecurityContext": {
-      "description": "Pod-level securityContext (runs as non-root uid/gid 1000 with fsGroup so the shared /config volume is writable).",
+      "description": "Pod-level securityContext (runs as non-root uid/gid 65532 with fsGroup so the shared /config volume is writable).",
       "properties": {
         "fsGroup": {
-          "default": 1000,
+          "default": 65532,
           "title": "fsGroup",
           "type": "integer"
         },
@@ -616,7 +616,7 @@
           "type": "string"
         },
         "runAsGroup": {
-          "default": 1000,
+          "default": 65532,
           "title": "runAsGroup",
           "type": "integer"
         },
@@ -626,7 +626,7 @@
           "type": "boolean"
         },
         "runAsUser": {
-          "default": 1000,
+          "default": 65532,
           "title": "runAsUser",
           "type": "integer"
         }

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -202,12 +202,12 @@ podAnnotations: {}
 # -- Labels added to the pod.
 podLabels: {}
 
-# -- Pod-level securityContext (runs as non-root uid/gid 1000 with fsGroup so the shared /config volume is writable).
+# -- Pod-level securityContext (runs as non-root uid/gid 65532 with fsGroup so the shared /config volume is writable).
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
   fsGroupChangePolicy: OnRootMismatch
 
 # -- Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Needs Kubernetes 1.34+, where PodLevelResources is beta and on by default; the chart's kubeVersion enforces this. Empty leaves it unset.


### PR DESCRIPTION
Aligns gatus-sidecar to the fleet-standard pod `securityContext` uid/gid/fsGroup **65532** (was 1000). gatus-sidecar writes state to disk (the shared `/config` volume), so `fsGroup` + `fsGroupChangePolicy: OnRootMismatch` stay — now at 65532.

Note: this pod also runs the upstream `ghcr.io/twin/gatus` container, which inherits the pod securityContext and now runs as 65532 too. The Helm E2E (kind) job deploys and probes the pod, validating both containers run at 65532.
