### PR TITLE
feat(chart): allow user-supplied initContainers

### DIFF
--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -95,6 +95,7 @@ Kubernetes: `>=1.34.0-0`
 | ingress.enabled | bool | `false` | Expose the UI via an Ingress. |
 | ingress.hosts | list | `[{"host":"gatus.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress hosts and their paths. |
 | ingress.tls | list | `[]` | Ingress TLS configuration. |
+| initContainers | list | `[]` | Extra initContainers (templated) added to the pod. They run, in order, before the gatus-sidecar native sidecar and the gatus container — use them to prep the shared config volume or wait on a dependency. For a long-running helper, set `restartPolicy: Always` to make it a native sidecar too. |
 | monitoring.serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations. |
 | monitoring.serviceMonitor.enabled | bool | `false` | Create a Prometheus Operator ServiceMonitor (requires its CRDs). Scrapes the http port at `path`. |
 | monitoring.serviceMonitor.interval | string | `"30s"` | Scrape interval. |

--- a/charts/gatus-sidecar/templates/deployment.tpl
+++ b/charts/gatus-sidecar/templates/deployment.tpl
@@ -47,12 +47,17 @@ spec:
       resources:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-      {{- if .Values.sidecar.enabled }}
-      # Native sidecar: an init container with restartPolicy: Always runs for the
-      # life of the pod, starting before — and stopping after — the gatus container.
-      # It watches the cluster and writes its generated config into the shared
-      # /config volume, which gatus then reads.
+      {{- if or .Values.initContainers .Values.sidecar.enabled }}
       initContainers:
+        {{- with .Values.initContainers }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+        {{- if .Values.sidecar.enabled }}
+        # Native sidecar: an init container with restartPolicy: Always runs for the
+        # life of the pod, starting before — and stopping after — the gatus container.
+        # It watches the cluster and writes its generated config into the shared
+        # /config volume, which gatus then reads. Any user initContainers above run
+        # to completion first.
         - name: gatus-sidecar
           image: {{ include "gatus-sidecar.sidecarImage" . | quote }}
           imagePullPolicy: {{ .Values.sidecar.image.pullPolicy }}
@@ -70,6 +75,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: {{ .Values.gatus.configPath }}
+        {{- end }}
       {{- end }}
       containers:
         - name: gatus

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -72,6 +72,35 @@ tests:
       - notExists:
           path: spec.template.spec.initContainers
 
+  - it: prepends user-supplied initContainers before the native sidecar
+    template: deployment.tpl
+    set:
+      initContainers:
+        - name: prep
+          image: mirror.gcr.io/busybox
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prep
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: gatus-sidecar
+
+  - it: renders user initContainers even when the sidecar is disabled
+    template: deployment.tpl
+    set:
+      sidecar.enabled: false
+      initContainers:
+        - name: prep
+          image: mirror.gcr.io/busybox
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prep
+
   - it: renders the default sidecar args from the structured config
     template: deployment.tpl
     asserts:

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -441,6 +441,14 @@
       "title": "ingress",
       "type": "object"
     },
+    "initContainers": {
+      "description": "Extra initContainers (templated) added to the pod. They run, in order, before the gatus-sidecar native sidecar and the gatus container — use them to prep the shared config volume or wait on a dependency. For a long-running helper, set `restartPolicy: Always` to make it a native sidecar too.",
+      "items": {
+        "required": []
+      },
+      "title": "initContainers",
+      "type": "array"
+    },
     "monitoring": {
       "properties": {
         "serviceMonitor": {

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -324,6 +324,8 @@ podDisruptionBudget:
   # @schema
   maxUnavailable: ""
 
+# -- Extra initContainers (templated) added to the pod. They run, in order, before the gatus-sidecar native sidecar and the gatus container — use them to prep the shared config volume or wait on a dependency. For a long-running helper, set `restartPolicy: Always` to make it a native sidecar too.
+initContainers: []
 # -- Additional volumes on the Deployment pod.
 volumes: []
 # -- Additional volume mounts on the gatus container.


### PR DESCRIPTION
Lets chart users add their own `initContainers` to the gatus pod. (The sidecar already runs as a native sidecar init container, so the field existed internally — this exposes a supported, documented knob.)

- `values.yaml` — new templated `initContainers: []`.
- `deployment.tpl` — user initContainers render **first** (run to completion), then the gatus-sidecar native sidecar; the `initContainers:` key now emits when *either* is set, so user init containers also work with `sidecar.enabled: false`.
- helm-unittest: prepend-order + sidecar-disabled cases. Schema/README regenerated.

No change to existing behavior — `initContainers: []` renders nothing extra.
