### PR TITLE
feat(chart): set the Service port to 8080 to match the container port

### DIFF
--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -123,7 +123,7 @@ Kubernetes: `>=1.34.0-0`
 | rbac.type | string | `"ClusterRole"` | RBAC scope: ClusterRole (watch all namespaces) or Role (single namespace; pair with the sidecar's `namespace`). |
 | replicaCount | int | `1` | Number of gatus replicas. Gatus is backed by a Deployment; with persistence enabled (a single RWO PVC) keep this at 1. |
 | resources | object | `{}` | Pod-level resource requests/limits — the Kubernetes `Pod.spec.resources` field, one budget shared by the gatus and sidecar containers (no need to split it per container). Needs Kubernetes 1.34+, where PodLevelResources is beta and on by default; the chart's kubeVersion enforces this. Empty leaves it unset. |
-| service.port | int | `80` | Service port (maps to the gatus web port; /metrics is served here too). |
+| service.port | int | `8080` | Service port (matches the gatus web/container port; /metrics is served here too). |
 | service.type | string | `"ClusterIP"` | Service type. |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount. |
 | serviceAccount.automount | bool | `true` | Automount the ServiceAccount API token (on by default: the sidecar needs Kubernetes API access to discover endpoints). |

--- a/charts/gatus-sidecar/tests/test-connection_test.yaml
+++ b/charts/gatus-sidecar/tests/test-connection_test.yaml
@@ -20,4 +20,4 @@ tests:
           value: true
       - contains:
           path: spec.containers[0].args
-          content: http://RELEASE-NAME-gatus-sidecar:80/health
+          content: http://RELEASE-NAME-gatus-sidecar:8080/health

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -691,8 +691,8 @@
     "service": {
       "properties": {
         "port": {
-          "default": 80,
-          "description": "Service port (maps to the gatus web port; /metrics is served here too).",
+          "default": 8080,
+          "description": "Service port (matches the gatus web/container port; /metrics is served here too).",
           "title": "port",
           "type": "integer"
         },

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -221,8 +221,8 @@ resources: {}
 service:
   # -- Service type.
   type: ClusterIP
-  # -- Service port (maps to the gatus web port; /metrics is served here too).
-  port: 80
+  # -- Service port (matches the gatus web/container port; /metrics is served here too).
+  port: 8080
 
 monitoring:
   serviceMonitor:


### PR DESCRIPTION
## What

Sets the chart's Service `port` from **80 → 8080**, matching gatus's container/web
port (the `targetPort`). The Service previously exposed `:80` and forwarded to the
container's `:8080`; now `port == targetPort == 8080` — no `:80` indirection, and
consistent with the 8080 web-port convention used across the apps.

## Notes

- The container port (gatus's `GATUS_WEB_PORT`, 8080) is unchanged.
- `ingress.tpl` and `httproute.tpl` reference the Service port **by name** (`http`),
  so they follow automatically. NOTES and the `helm test` pod template the port too.
- Only thing affected: consumers hitting the Service on `:80` directly now use `:8080`
  (an Ingress/HTTPRoute fronts external `:80`/`:443` → service `:8080` as before).
- Verified: `helm lint` clean, `helm unittest` 49/49, README + values schema regenerated.
