### PR TITLE
feat(chart): default the Deployment update strategy to Recreate

### DIFF
--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -147,6 +147,7 @@ Kubernetes: `>=1.34.0-0`
 | sidecar.output | string | `""` | File the sidecar writes generated YAML to (--output); empty defaults to `<gatus.configPath>/gatus-sidecar.yaml` (in the shared volume). |
 | sidecar.probePaths | bool | `true` | Include paths from match rules in probe URLs (--probe-paths); false probes bare hostnames. |
 | sidecar.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | gatus-sidecar container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities). |
+| strategy | object | `{"type":"Recreate"}` | Deployment update strategy. Defaults to `Recreate` because gatus can be stateful: with `persistence` on (a single ReadWriteOnce PVC) a RollingUpdate would start the new pod before the old one releases the volume, which a RWO volume can't satisfy — deadlocking the rollout. Set `{type: RollingUpdate, rollingUpdate: {...}}` for a stateless deployment (persistence off, or an RWX volume). |
 | terminationGracePeriodSeconds | int | `30` | Grace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM). |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |
 | tests.image.repository | string | `"mirror.gcr.io/curlimages/curl"` | `helm test` connection-pod image; a gcr-mirrored curl, so the test never pulls from Docker Hub. |

--- a/charts/gatus-sidecar/templates/deployment.tpl
+++ b/charts/gatus-sidecar/templates/deployment.tpl
@@ -13,6 +13,10 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "gatus-sidecar.selectorLabels" . | nindent 6 }}

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -18,6 +18,28 @@ tests:
       - notExists:
           path: spec.volumeClaimTemplates
 
+  - it: defaults to the Recreate update strategy (stateful-safe with a RWO PVC)
+    template: deployment.tpl
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: honors a RollingUpdate strategy override
+    template: deployment.tpl
+    set:
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+
   - it: defaults the gatus image to repository:appVersion when no digest or tag is set
     template: deployment.tpl
     set:

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -990,6 +990,19 @@
       "title": "sidecar",
       "type": "object"
     },
+    "strategy": {
+      "description": "Deployment update strategy. Defaults to `Recreate` because gatus can be stateful: with `persistence` on (a single ReadWriteOnce PVC) a RollingUpdate would start the new pod before the old one releases the volume, which a RWO volume can't satisfy — deadlocking the rollout. Set `{type: RollingUpdate, rollingUpdate: {...}}` for a stateless deployment (persistence off, or an RWX volume).",
+      "properties": {
+        "type": {
+          "default": "Recreate",
+          "title": "type",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "strategy",
+      "type": "object"
+    },
     "terminationGracePeriodSeconds": {
       "default": 30,
       "description": "Grace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM).",

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -19,6 +19,10 @@
 # -- Number of gatus replicas. Gatus is backed by a Deployment; with persistence enabled (a single RWO PVC) keep this at 1.
 replicaCount: 1
 
+# -- Deployment update strategy. Defaults to `Recreate` because gatus can be stateful: with `persistence` on (a single ReadWriteOnce PVC) a RollingUpdate would start the new pod before the old one releases the volume, which a RWO volume can't satisfy — deadlocking the rollout. Set `{type: RollingUpdate, rollingUpdate: {...}}` for a stateless deployment (persistence off, or an RWX volume).
+strategy:
+  type: Recreate
+
 # Upstream Gatus — image and runtime settings. This image is pulled, never built
 # by this repo.
 gatus:


### PR DESCRIPTION
## What

Adds a `strategy` value (Deployment update strategy) and **defaults it to `Recreate`**.

## Why

Gatus can be stateful: with `persistence` enabled the Deployment mounts a single
**ReadWriteOnce** PVC. The Deployment previously had no `strategy`, so it used
Kubernetes' default **RollingUpdate** — which spins up the new pod *before* the old
one is gone. A RWO volume can only attach to one node/pod, so the new pod gets stuck
`Pending` (`Multi-Attach`/`FailedAttachVolume`) and the rollout deadlocks. This is the
classic "HelmRelease upgrade hangs" failure for a stateful Deployment + RWO PVC.

`Recreate` terminates the old pod first, releasing the volume, then starts the new one.

## Exposed either way

`strategy` is a full passthrough, so stateless deployments (persistence off, or an RWX
volume) can opt back in:

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 1
```

Verified: `helm lint` clean; `helm unittest` 51/51 (added default-Recreate + RollingUpdate-override cases); README + values schema regenerated.
