### PR TITLE
style: indent markdown at 2 to match embedded yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = false
 
 [Dockerfile]

--- a/README.md
+++ b/README.md
@@ -57,27 +57,27 @@ sub-config.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    name: gatus
+  name: gatus
 spec:
-    template:
-        spec:
-            serviceAccountName: gatus-sidecar
-            containers:
-                - name: gatus
-                  image: ghcr.io/twin/gatus:latest
-                  volumeMounts:
-                      - { name: gatus-config, mountPath: /config }
-                - name: gatus-sidecar
-                  image: ghcr.io/home-operations/gatus-sidecar:latest
-                  args:
-                      - --auto-ingress
-                      - --auto-service
-                      - --auto-httproute
-                      - --gateway-name=production
-                  volumeMounts:
-                      - { name: gatus-config, mountPath: /config }
-            volumes:
-                - { name: gatus-config, emptyDir: {} }
+  template:
+    spec:
+      serviceAccountName: gatus-sidecar
+      containers:
+        - name: gatus
+          image: ghcr.io/twin/gatus:latest
+          volumeMounts:
+            - { name: gatus-config, mountPath: /config }
+        - name: gatus-sidecar
+          image: ghcr.io/home-operations/gatus-sidecar:latest
+          args:
+            - --auto-ingress
+            - --auto-service
+            - --auto-httproute
+            - --gateway-name=production
+          volumeMounts:
+            - { name: gatus-config, mountPath: /config }
+      volumes:
+        - { name: gatus-config, emptyDir: {} }
 ```
 
 Minimum RBAC for the controllers you enable:
@@ -87,18 +87,18 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: { name: gatus-sidecar }
 rules:
-    - apiGroups: [""]
-      resources: ["services"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["networking.k8s.io"]
-      resources: ["ingresses", "ingressclasses"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["gateway.networking.k8s.io"]
-      resources: ["httproutes", "gateways"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["traefik.io"]
-      resources: ["ingressroutes"]
-      verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "ingressclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes", "gateways"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["traefik.io"]
+    resources: ["ingressroutes"]
+    verbs: ["get", "list", "watch"]
 ```
 
 ## Configuration
@@ -204,9 +204,9 @@ but you still want to know DNS is resolving.
 
 ```yaml
 metadata:
-    annotations:
-        gatus.home-operations.com/endpoint: |
-            guarded: true
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      guarded: true
 ```
 
 ## Examples
@@ -217,28 +217,28 @@ metadata:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-    name: prod
-    annotations:
-        gatus.home-operations.com/endpoint: |
-            alerts:
-              - type: slack
-                webhook-url: https://hooks.slack.com/...
+  name: prod
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      alerts:
+        - type: slack
+          webhook-url: https://hooks.slack.com/...
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-    name: api
-    annotations:
-        gatus.home-operations.com/endpoint: |
-            interval: 30s
-            conditions:
-              - "[STATUS] == 200"
-              - "[RESPONSE_TIME] < 500"
+  name: api
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      interval: 30s
+      conditions:
+        - "[STATUS] == 200"
+        - "[RESPONSE_TIME] < 500"
 spec:
-    parentRefs: [{ name: prod }]
-    hostnames: ["api.example.com"]
-    rules:
-        - matches: [{ path: { type: PathPrefix, value: "/v1" } }]
+  parentRefs: [{ name: prod }]
+  hostnames: ["api.example.com"]
+  rules:
+    - matches: [{ path: { type: PathPrefix, value: "/v1" } }]
 ```
 
 Generated endpoint URL: `https://api.example.com/v1` — inherits the Gateway's


### PR DESCRIPTION
Mirrors the canonical change in home-operations/.github#37.

`oxfmt` applies a markdown file's `tabWidth` to embedded code blocks. With `[*.md] indent_size = 4`, yaml examples inside the docs get rewritten to 4-space indentation while the yaml files they document stay at 2 under `[*] indent_size = 2`. Anyone copying from the README gets the wrong style. This sets `[*.md] indent_size = 2`.

The reformat is cosmetic: verified across the org that rendered markdown structure is unchanged (no new indented-code-blocks, identical list nesting) and that embedded yaml parses to identical values, block scalars included. Reindented with the repo's pinned oxfmt.