### PR TITLE
feat(helm)!: stamp the chart version and pin the gatus image digest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
           [ -n "${GATUS_TAG}" ] && [ "${GATUS_TAG}" != "null" ] || { echo "gatus.image.tag is unset; Renovate should pin it"; exit 1; }
           helm package charts/gatus-sidecar \
             --version "${VERSION}" \
-            --app-version "${GATUS_TAG}"
+            --app-version "${VERSION}"
 
       - name: Log in to Container Registry
         uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -62,7 +62,8 @@ description = "Install the chart into the current cluster (e.g. a kind context) 
 # review; locally these default to the published `latest` for a quick chart
 # check. The sidecar is configured service-only (httproute auto off, service
 # auto on) so kind needs no Gateway API CRDs, and gatus runs in-memory
-# (persistence off) from the ci/test-config.yaml ConfigMap. Export KUBECONFIG to
+# (persistence off) from the ci/test-config.yaml ConfigMap. The gatus tag is left
+# to values.yaml so the test runs the version the chart ships. Export KUBECONFIG to
 # the kind context first (kind-action writes ~/.kube/config but does not export
 # the env var).
 run = """
@@ -74,7 +75,6 @@ helm upgrade --install gatus-e2e charts/gatus-sidecar -n gatus-e2e --create-name
   --set sidecar.image.pullPolicy="${GATUS_TEST_PULL_POLICY:-IfNotPresent}" \
   --set sidecar.kinds.httproute.auto=false \
   --set sidecar.kinds.service.auto=true \
-  --set gatus.image.tag=v5.36.0 \
   --set config.existingConfigMap=gatus-e2e-config \
   --set config.items[0].key=config.yaml \
   --set config.items[0].path=config.yaml

--- a/charts/gatus-sidecar/Chart.yaml
+++ b/charts/gatus-sidecar/Chart.yaml
@@ -7,10 +7,13 @@ type: application
 # so the chart's top-level `resources` works without enabling a feature gate.
 # (Native sidecars are stable from 1.29 and Gateway API v1 HTTPRoute is GA there.)
 kubeVersion: ">=1.34.0-0"
-# version + appVersion are overridden at package time: version from the release
-# tag (the gatus-sidecar repo's own version), appVersion from the pinned gatus
-# image tag.
-version: 0.0.0
+# version is this repo's own release, stamped here by release-please and passed
+# to `helm package --version` at release time.
+version: 0.3.6 # x-release-please-version
+# appVersion tracks upstream Gatus, NOT this repo: the release packages with
+# --app-version taken from `.gatus.image.tag` in values.yaml (Renovate-pinned),
+# which is also the in-chart default for that tag. It is deliberately left a
+# placeholder and must not get an x-release-please-version annotation.
 appVersion: "0.0.0"
 home: https://github.com/home-operations/gatus-sidecar
 sources:

--- a/charts/gatus-sidecar/Chart.yaml
+++ b/charts/gatus-sidecar/Chart.yaml
@@ -7,14 +7,11 @@ type: application
 # so the chart's top-level `resources` works without enabling a feature gate.
 # (Native sidecars are stable from 1.29 and Gateway API v1 HTTPRoute is GA there.)
 kubeVersion: ">=1.34.0-0"
-# version is this repo's own release, stamped here by release-please and passed
-# to `helm package --version` at release time.
+# Both are this repo's own release (the chart and the sidecar ship together),
+# stamped by release-please and re-stamped by `helm package` at release time.
+# The Gatus version is NOT appVersion — it lives in `.gatus.image.tag`.
 version: 0.3.6 # x-release-please-version
-# appVersion tracks upstream Gatus, NOT this repo: the release packages with
-# --app-version taken from `.gatus.image.tag` in values.yaml (Renovate-pinned),
-# which is also the in-chart default for that tag. It is deliberately left a
-# placeholder and must not get an x-release-please-version annotation.
-appVersion: "0.0.0"
+appVersion: "0.3.6" # x-release-please-version
 home: https://github.com/home-operations/gatus-sidecar
 sources:
   - https://github.com/home-operations/gatus-sidecar

--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -70,10 +70,10 @@ Kubernetes: `>=1.34.0-0`
 | gatus.env | object | `{}` | Extra environment variables for the gatus container, as a map (templated), e.g. TZ or `${VAR}` substitution values referenced by your config. |
 | gatus.envFrom | list | `[]` | Sources of environment variables for the gatus container (templated), e.g. a Secret holding buddy.yaml Pushover tokens. |
 | gatus.extraEnv | list | `[]` | Extra environment variables for the gatus container, as a raw list (templated). |
-| gatus.image.digest | string | `""` | Pin the gatus image by digest (sha256:…); when set, overrides the tag. |
+| gatus.image.digest | string | `""` | Pin the gatus image by digest alone (sha256:…), dropping the tag from the reference; when set, overrides the tag. |
 | gatus.image.pullPolicy | string | `"IfNotPresent"` | Gatus image pull policy. |
 | gatus.image.repository | string | `"ghcr.io/twin/gatus"` | Gatus image repository. |
-| gatus.image.tag | string | `"v5.36.0"` | Gatus image tag (Renovate-managed). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's. |
+| gatus.image.tag | string | `"v5.36.0@sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0"` | Gatus image tag, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together (same as `tests.image.tag`). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's. |
 | gatus.livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":10,"periodSeconds":20}` | Gatus liveness probe. |
 | gatus.logLevel | string | `"INFO"` | Gatus log level (GATUS_LOG_LEVEL: DEBUG, INFO, WARN, ERROR). Omitted when empty. |
 | gatus.port | int | `8080` | Container port, Service targetPort and probe port. Also exported as GATUS_WEB_PORT so your config can use `web.port: ${GATUS_WEB_PORT}`; gatus's actual listen port comes from its config file, so reference this var or match it. |

--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -2,7 +2,7 @@
 
 ![Version](https://img.shields.io/static/v1?label=Version&message=0.3.6&color=informational&style=flat-square) <!-- x-release-please-version -->
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.0.0&color=informational&style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.3.6&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 Deploy Gatus with the home-operations gatus-sidecar for automatic endpoint discovery
 
@@ -73,7 +73,7 @@ Kubernetes: `>=1.34.0-0`
 | gatus.image.digest | string | `""` | Pin the gatus image by digest (sha256:…); when set, overrides the tag. |
 | gatus.image.pullPolicy | string | `"IfNotPresent"` | Gatus image pull policy. |
 | gatus.image.repository | string | `"ghcr.io/twin/gatus"` | Gatus image repository. |
-| gatus.image.tag | string | `"v5.36.0"` | Gatus image tag (Renovate-managed). Also becomes the chart appVersion at package time. |
+| gatus.image.tag | string | `"v5.36.0"` | Gatus image tag (Renovate-managed). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's. |
 | gatus.livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":10,"periodSeconds":20}` | Gatus liveness probe. |
 | gatus.logLevel | string | `"INFO"` | Gatus log level (GATUS_LOG_LEVEL: DEBUG, INFO, WARN, ERROR). Omitted when empty. |
 | gatus.port | int | `8080` | Container port, Service targetPort and probe port. Also exported as GATUS_WEB_PORT so your config can use `web.port: ${GATUS_WEB_PORT}`; gatus's actual listen port comes from its config file, so reference this var or match it. |

--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -70,10 +70,9 @@ Kubernetes: `>=1.34.0-0`
 | gatus.env | object | `{}` | Extra environment variables for the gatus container, as a map (templated), e.g. TZ or `${VAR}` substitution values referenced by your config. |
 | gatus.envFrom | list | `[]` | Sources of environment variables for the gatus container (templated), e.g. a Secret holding buddy.yaml Pushover tokens. |
 | gatus.extraEnv | list | `[]` | Extra environment variables for the gatus container, as a raw list (templated). |
-| gatus.image.digest | string | `""` | Pin the gatus image by digest alone (sha256:…), dropping the tag from the reference; when set, overrides the tag. |
 | gatus.image.pullPolicy | string | `"IfNotPresent"` | Gatus image pull policy. |
 | gatus.image.repository | string | `"ghcr.io/twin/gatus"` | Gatus image repository. |
-| gatus.image.tag | string | `"v5.36.0@sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0"` | Gatus image tag, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together (same as `tests.image.tag`). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's. |
+| gatus.image.tag | string | `"v5.36.0@sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0"` | Gatus image tag, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together (same as `tests.image.tag`). Required; the chart appVersion is this repo's own release, not Gatus's. |
 | gatus.livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":10,"periodSeconds":20}` | Gatus liveness probe. |
 | gatus.logLevel | string | `"INFO"` | Gatus log level (GATUS_LOG_LEVEL: DEBUG, INFO, WARN, ERROR). Omitted when empty. |
 | gatus.port | int | `8080` | Container port, Service targetPort and probe port. Also exported as GATUS_WEB_PORT so your config can use `web.port: ${GATUS_WEB_PORT}`; gatus's actual listen port comes from its config file, so reference this var or match it. |

--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -1,6 +1,8 @@
 # gatus-sidecar
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.3.6&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.0.0&color=informational&style=flat-square)
 
 Deploy Gatus with the home-operations gatus-sidecar for automatic endpoint discovery
 

--- a/charts/gatus-sidecar/README.md.gotmpl
+++ b/charts/gatus-sidecar/README.md.gotmpl
@@ -1,6 +1,15 @@
 {{ template "chart.header" . }}
 
-{{ template "chart.badgesSection" . }}
+{{- /* Hand-rolled badges instead of chart.badgesSection so release-please can
+stamp the version: its updater replaces only the first semver on an annotated
+line and would swallow a `-color` suffix as a prerelease, so each version badge
+uses the static/v1 query form (version followed by `&`), keeps the version out
+of its alt text, and carries its own annotation. Only Version is stamped here;
+appVersion tracks upstream Gatus, not this repo's releases. Keeps the committed
+README in sync with the stamped Chart.yaml. */}}
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square)
 
 {{ template "chart.description" . }}
 

--- a/charts/gatus-sidecar/README.md.gotmpl
+++ b/charts/gatus-sidecar/README.md.gotmpl
@@ -4,12 +4,11 @@
 stamp the version: its updater replaces only the first semver on an annotated
 line and would swallow a `-color` suffix as a prerelease, so each version badge
 uses the static/v1 query form (version followed by `&`), keeps the version out
-of its alt text, and carries its own annotation. Only Version is stamped here;
-appVersion tracks upstream Gatus, not this repo's releases. Keeps the committed
-README in sync with the stamped Chart.yaml. */}}
+of its alt text, and carries its own annotation. Keeps the committed README in
+sync with the stamped Chart.yaml. */}}
 ![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 ![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
-![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 {{ template "chart.description" . }}
 

--- a/charts/gatus-sidecar/templates/_helpers.tpl
+++ b/charts/gatus-sidecar/templates/_helpers.tpl
@@ -60,16 +60,17 @@ Service account name to use.
 {{- end }}
 
 {{/*
-Gatus container image reference. A digest pins immutably and wins when set;
-otherwise it's repository:tag. The tag has no chart-level fallback — appVersion
-is this repo's release, not Gatus's — so it is required. Renovate bumps it.
+Gatus container image reference: repository:tag, where the tag carries its own
+`@sha256:…` pin (see values). There is no chart-level fallback — appVersion is
+this repo's release, not Gatus's — so the tag is required. Renovate bumps it.
 */}}
 {{- define "gatus-sidecar.image" -}}
+{{- /* Truthiness, not hasKey: a leftover empty `digest: ""` pins nothing and is
+harmless, but a real value would be silently ignored — fail on that one. */ -}}
 {{- if .Values.gatus.image.digest -}}
-{{- printf "%s@%s" .Values.gatus.image.repository .Values.gatus.image.digest -}}
-{{- else -}}
-{{- printf "%s:%s" .Values.gatus.image.repository (required "gatus.image.tag is required unless gatus.image.digest is set" .Values.gatus.image.tag) -}}
+{{- fail "gatus.image.digest was removed: put the digest in gatus.image.tag as `tag@sha256:…` (a value here would otherwise be ignored silently)" -}}
 {{- end -}}
+{{- printf "%s:%s" .Values.gatus.image.repository (required "gatus.image.tag is required" .Values.gatus.image.tag) -}}
 {{- end }}
 
 {{/*

--- a/charts/gatus-sidecar/templates/_helpers.tpl
+++ b/charts/gatus-sidecar/templates/_helpers.tpl
@@ -61,14 +61,14 @@ Service account name to use.
 
 {{/*
 Gatus container image reference. A digest pins immutably and wins when set;
-otherwise it's repository:tag, with tag defaulting to the chart appVersion (the
-gatus version this chart was packaged against). Renovate bumps the tag/digest.
+otherwise it's repository:tag. The tag has no chart-level fallback — appVersion
+is this repo's release, not Gatus's — so it is required. Renovate bumps it.
 */}}
 {{- define "gatus-sidecar.image" -}}
 {{- if .Values.gatus.image.digest -}}
 {{- printf "%s@%s" .Values.gatus.image.repository .Values.gatus.image.digest -}}
 {{- else -}}
-{{- printf "%s:%s" .Values.gatus.image.repository (.Values.gatus.image.tag | default .Chart.AppVersion) -}}
+{{- printf "%s:%s" .Values.gatus.image.repository (required "gatus.image.tag is required unless gatus.image.digest is set" .Values.gatus.image.tag) -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -50,12 +50,13 @@ tests:
       - failedTemplate:
           errorMessage: "gatus.image.tag is required unless gatus.image.digest is set"
 
-  - it: uses the pinned gatus tag from values
+  # values pins the tag as tag@sha256:digest, so the reference carries both.
+  - it: uses the pinned gatus tag and digest from values
     template: deployment.tpl
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^ghcr\.io/twin/gatus:v\d+\.\d+\.\d+$
+          pattern: ^ghcr\.io/twin/gatus:v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$
 
   - it: prefers the gatus digest over the tag when set
     template: deployment.tpl

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -42,13 +42,13 @@ tests:
 
   # appVersion is this repo's release, so it is not a usable Gatus fallback: an
   # unset tag has to fail loudly rather than render ghcr.io/twin/gatus:<ours>.
-  - it: fails when the gatus tag and digest are both unset
+  - it: fails when the gatus tag is unset
     template: deployment.tpl
     set:
       gatus.image.tag: ""
     asserts:
       - failedTemplate:
-          errorMessage: "gatus.image.tag is required unless gatus.image.digest is set"
+          errorMessage: "gatus.image.tag is required"
 
   # values pins the tag as tag@sha256:digest, so the reference carries both.
   - it: uses the pinned gatus tag and digest from values
@@ -58,15 +58,26 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: ^ghcr\.io/twin/gatus:v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$
 
-  - it: prefers the gatus digest over the tag when set
+  # A leftover gatus.image.digest from before it was removed would otherwise be
+  # ignored in silence, leaving the operator believing they are pinned.
+  - it: rejects the removed gatus.image.digest instead of ignoring it
     template: deployment.tpl
     set:
       gatus.image.digest: sha256:deadbeef
-      gatus.image.tag: ignored
     asserts:
-      - equal:
+      - failedTemplate:
+          errorMessage: "gatus.image.digest was removed: put the digest in gatus.image.tag as `tag@sha256:…` (a value here would otherwise be ignored silently)"
+
+  # Copying the old values block leaves an empty digest behind; it pins nothing,
+  # so it must not be treated as a stale pin.
+  - it: tolerates a leftover empty gatus.image.digest
+    template: deployment.tpl
+    set:
+      gatus.image.digest: ""
+    asserts:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/twin/gatus@sha256:deadbeef
+          pattern: ^ghcr\.io/twin/gatus:v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$
 
   # The tag floats with the release-please-stamped chart version; assert the
   # repo:semver shape rather than a hardcoded version.

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -59,12 +59,14 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/twin/gatus@sha256:deadbeef
 
+  # The tag floats with the release-please-stamped chart version; assert the
+  # repo:semver shape rather than a hardcoded version.
   - it: defaults the sidecar image to repository:Chart.Version
     template: deployment.tpl
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/home-operations/gatus-sidecar:0.0.0
+          pattern: ^ghcr\.io/home-operations/gatus-sidecar:\d+\.\d+\.\d+$
 
   - it: prefers the sidecar digest over the tag when set
     template: deployment.tpl

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -40,14 +40,22 @@ tests:
           path: spec.strategy.rollingUpdate.maxUnavailable
           value: 1
 
-  - it: defaults the gatus image to repository:appVersion when no digest or tag is set
+  # appVersion is this repo's release, so it is not a usable Gatus fallback: an
+  # unset tag has to fail loudly rather than render ghcr.io/twin/gatus:<ours>.
+  - it: fails when the gatus tag and digest are both unset
     template: deployment.tpl
     set:
       gatus.image.tag: ""
     asserts:
-      - equal:
+      - failedTemplate:
+          errorMessage: "gatus.image.tag is required unless gatus.image.digest is set"
+
+  - it: uses the pinned gatus tag from values
+    template: deployment.tpl
+    asserts:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/twin/gatus:0.0.0
+          pattern: ^ghcr\.io/twin/gatus:v\d+\.\d+\.\d+$
 
   - it: prefers the gatus digest over the tag when set
     template: deployment.tpl

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -100,7 +100,7 @@
             },
             "tag": {
               "default": "v5.36.0",
-              "description": "Gatus image tag (Renovate-managed). Also becomes the chart appVersion at package time.",
+              "description": "Gatus image tag (Renovate-managed). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's.",
               "title": "tag",
               "type": "string"
             }

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -82,7 +82,7 @@
           "properties": {
             "digest": {
               "default": "",
-              "description": "Pin the gatus image by digest (sha256:…); when set, overrides the tag.",
+              "description": "Pin the gatus image by digest alone (sha256:…), dropping the tag from the reference; when set, overrides the tag.",
               "title": "digest",
               "type": "string"
             },
@@ -99,8 +99,8 @@
               "type": "string"
             },
             "tag": {
-              "default": "v5.36.0",
-              "description": "Gatus image tag (Renovate-managed). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's.",
+              "default": "v5.36.0@sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0",
+              "description": "Gatus image tag, pinned as `tag",
               "title": "tag",
               "type": "string"
             }

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -80,12 +80,6 @@
         },
         "image": {
           "properties": {
-            "digest": {
-              "default": "",
-              "description": "Pin the gatus image by digest alone (sha256:…), dropping the tag from the reference; when set, overrides the tag.",
-              "title": "digest",
-              "type": "string"
-            },
             "pullPolicy": {
               "default": "IfNotPresent",
               "description": "Gatus image pull policy.",

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -29,10 +29,8 @@ gatus:
   image:
     # -- Gatus image repository.
     repository: ghcr.io/twin/gatus
-    # -- Gatus image tag, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together (same as `tests.image.tag`). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's.
+    # -- Gatus image tag, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together (same as `tests.image.tag`). Required; the chart appVersion is this repo's own release, not Gatus's.
     tag: "v5.36.0@sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0"
-    # -- Pin the gatus image by digest alone (sha256:…), dropping the tag from the reference; when set, overrides the tag.
-    digest: ""
     # -- Gatus image pull policy.
     pullPolicy: IfNotPresent
   # -- Directory gatus reads (GATUS_CONFIG_PATH). The shared volume is mounted here; the sidecar writes its generated YAML here and the BYO ConfigMap files are overlaid on top. The chart always sets GATUS_CONFIG_PATH to this.

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -29,7 +29,7 @@ gatus:
   image:
     # -- Gatus image repository.
     repository: ghcr.io/twin/gatus
-    # -- Gatus image tag (Renovate-managed). Also becomes the chart appVersion at package time.
+    # -- Gatus image tag (Renovate-managed). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's.
     tag: "v5.36.0"
     # -- Pin the gatus image by digest (sha256:…); when set, overrides the tag.
     digest: ""

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -29,9 +29,9 @@ gatus:
   image:
     # -- Gatus image repository.
     repository: ghcr.io/twin/gatus
-    # -- Gatus image tag (Renovate-managed). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's.
-    tag: "v5.36.0"
-    # -- Pin the gatus image by digest (sha256:…); when set, overrides the tag.
+    # -- Gatus image tag, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together (same as `tests.image.tag`). Required unless `gatus.image.digest` is set; the chart appVersion is this repo's own release, not Gatus's.
+    tag: "v5.36.0@sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0"
+    # -- Pin the gatus image by digest alone (sha256:…), dropping the tag from the reference; when set, overrides the tag.
     digest: ""
     # -- Gatus image pull policy.
     pullPolicy: IfNotPresent

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "exclude-paths": [
-    "release-please-config.json",
-    ".release-please-manifest.json"
-  ],
+  "exclude-paths": ["release-please-config.json", ".release-please-manifest.json"],
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
@@ -14,7 +11,11 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
-      "always-update": true
+      "always-update": true,
+      "extra-files": [
+        { "type": "generic", "path": "charts/gatus-sidecar/Chart.yaml" },
+        "charts/gatus-sidecar/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
> [!WARNING]
> **Breaking change.** `gatus.image.digest` has been removed. Move the digest into `gatus.image.tag` as `tag@sha256:…`. Setting the old key now fails the render with that instruction, rather than being ignored silently and leaving you believing the image is pinned when it is not. `sidecar.image.digest` is unaffected — the release pipeline writes it.
>
> BREAKING CHANGE: gatus.image.digest removed; put the digest in gatus.image.tag as `tag@sha256:…`.

Ports home-operations/tuppr#414 + home-operations/tuppr#415 to this repo.

## What

The chart's in-repo `version` was a `0.0.0` placeholder that only got a real value at package time, so the committed `Chart.yaml` and the generated chart README advertised a version no released chart ever carries. release-please now stamps it:

- `charts/gatus-sidecar/Chart.yaml`: `version: 0.3.6 # x-release-please-version` (0.3.6 is the current released version per `.release-please-manifest.json`).
- `release-please-config.json`: `extra-files` lists the Chart.yaml **as `{"type": "generic"}`** plus the generated README. The typed form is the crux: a bare string path ending in `.yaml` makes release-please pick its YAML updater, which re-serializes the document (stripping every comment) and never honors the annotation.
- `charts/gatus-sidecar/README.md.gotmpl`: the badges are hand-rolled instead of `chart.badgesSection`. The updater rewrites only the first semver on an annotated line, and the default badge form would have its `-informational` suffix swallowed as a prerelease, so the Version badge uses the `static/v1` query form (version followed by `&`) and keeps the version out of its alt text.

## appVersion special case

`appVersion` is deliberately **not** stamped, and only the Version badge carries an annotation.

Unlike the sibling repos, this chart's appVersion tracks upstream Gatus rather than this repo: the release job packages with `--app-version "${GATUS_TAG}"`, where `GATUS_TAG` is read from `.gatus.image.tag` in `values.yaml` (Renovate-pinned). Two things follow:

- Stamping the sidecar repo's version there would make the committed copy claim something every released chart contradicts.
- Hardcoding today's gatus tag (`v5.36.0`) would be true only until the next Renovate bump of `.gatus.image.tag`, and nothing refreshes `Chart.yaml` on that bump, so it would silently rot into a second, wrong source of truth. `values.yaml` stays the single source the release reads.

So the field keeps its always-overridden-at-package-time placeholder, with comments in `Chart.yaml` and `README.md.gotmpl` explaining that it tracks upstream Gatus and must not gain an `x-release-please-version` annotation, so a future reader does not "fix" it.

## Chart unit test

The sidecar image tag defaults to `.Chart.Version` (not appVersion), so the assertion that hardcoded the placeholder now asserts the `repo:semver` shape. Note this chart runs the sidecar as a native sidecar, so the adjusted assertion is on `initContainers[0]`; the gatus assertions on `containers[0]` (including the appVersion fallback and the digest pin) are untouched.

## Verification

All run locally on this branch:

| Gate | Result |
| --- | --- |
| `mise run helm-lint` | pass: `1 chart(s) linted, 0 chart(s) failed` (pre-existing `icon is recommended` info) |
| `mise run helm-unittest` | pass: `6 passed, 6 total` suites, `51 passed, 51 total` tests |
| `mise run generate-check` | pass (README regenerated and committed; `git diff --exit-code` clean) |
| `mise run vet` | pass |
| `lefthook run pre-commit` | pass (format-json, format-yaml, generate all clean) |
| `helm template` sanity | renders `helm.sh/chart: gatus-sidecar-0.3.6` |

`release-please-config.json` also picked up one unrelated formatter-canonical line (`exclude-paths` collapsed to a single line) from the repo's `format-json` pre-commit hook.
