### PR TITLE
docs: point the CI badge at ci.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 > A Kubernetes sidecar for [Gatus](https://github.com/TwiN/gatus) — turns Ingress, Service, Gateway API HTTPRoute, and Traefik IngressRoute resources into Gatus endpoint configuration, automatically.
 
-[![CI](https://github.com/home-operations/gatus-sidecar/actions/workflows/tests.yaml/badge.svg)](https://github.com/home-operations/gatus-sidecar/actions/workflows/tests.yaml)
-[![E2E](https://github.com/home-operations/gatus-sidecar/actions/workflows/e2e.yaml/badge.svg)](https://github.com/home-operations/gatus-sidecar/actions/workflows/e2e.yaml)
-[![Lint](https://github.com/home-operations/gatus-sidecar/actions/workflows/lint.yaml/badge.svg)](https://github.com/home-operations/gatus-sidecar/actions/workflows/lint.yaml)
+[![CI](https://github.com/home-operations/gatus-sidecar/actions/workflows/ci.yaml/badge.svg)](https://github.com/home-operations/gatus-sidecar/actions/workflows/ci.yaml)
 [![Release](https://img.shields.io/github/v/release/home-operations/gatus-sidecar)](https://github.com/home-operations/gatus-sidecar/releases)
 [![License](https://img.shields.io/github/license/home-operations/gatus-sidecar)](LICENSE)
 


### PR DESCRIPTION
## Overview

The `Tests`, `Lint` and `E2E` workflows were consolidated into `ci.yaml`, so the
README badges pointed at workflow files that no longer exist and rendered as
"no status". They collapse into a single `CI` badge.

Missed in the consolidation PR — the badges are Markdown, so nothing in
`actionlint`/`zizmor` or the workflow diff surfaced them.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.
