### PR TITLE
feat(chart): expose pod dnsPolicy and dnsConfig

### DIFF
--- a/charts/gatus-sidecar/README.md
+++ b/charts/gatus-sidecar/README.md
@@ -64,6 +64,8 @@ Kubernetes: `>=1.34.0-0`
 | config.existingConfigMap | string | `""` | REQUIRED: name of a ConfigMap holding your gatus config file(s) (templated, so a release-derived name works). |
 | config.items | list | `[]` | ConfigMap keys to mount read-only into gatus.configPath; each `{ key, path }` mounts the ConfigMap's `key` at `<configPath>/<path>` (subPath). |
 | deploymentAnnotations | object | `{}` | Annotations added to the Deployment (workload) metadata, e.g. `reloader.stakater.com/auto: "true"` so Stakater Reloader rolls the pod when the mounted config ConfigMap changes (Reloader reads the workload, not the pod). |
+| dnsConfig | object | `{}` | Pod dnsConfig (templated). Kubelet's default `ndots:5` makes the resolver walk the pod's DNS search list for every probe hostname, so each check burns extra guaranteed-NXDOMAIN lookups; when an endpoint template sets `client.dns-resolver`, that walk goes to the external resolver and leaks internal `<namespace>.svc.cluster.local` names to it. Setting `ndots: "1"` (example below) makes external hostnames resolve directly. |
+| dnsPolicy | string | `""` | Pod dnsPolicy (templated); empty leaves it to Kubernetes (ClusterFirst). Only needed alongside `dnsConfig` overrides that require a specific policy (e.g. `None`). |
 | fullnameOverride | string | `""` | Override the full release name. |
 | gatus.configPath | string | `"/config"` | Directory gatus reads (GATUS_CONFIG_PATH). The shared volume is mounted here; the sidecar writes its generated YAML here and the BYO ConfigMap files are overlaid on top. The chart always sets GATUS_CONFIG_PATH to this. |
 | gatus.delayStartSeconds | string | `""` | Delay gatus startup by N seconds (GATUS_DELAY_START_SECONDS). Omitted when empty or 0. |

--- a/charts/gatus-sidecar/templates/deployment.tpl
+++ b/charts/gatus-sidecar/templates/deployment.tpl
@@ -41,6 +41,16 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ tpl . $ | quote }}
       {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ tpl . $ | quote }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      # Typically ndots:1 so external probe hostnames skip the cluster DNS search
+      # list; with client.dns-resolver the NXDOMAIN walk would otherwise hit the
+      # external resolver and leak internal names to it.
+      dnsConfig:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- tpl (toYaml .Values.podSecurityContext) $ | nindent 8 }}

--- a/charts/gatus-sidecar/tests/deployment_test.yaml
+++ b/charts/gatus-sidecar/tests/deployment_test.yaml
@@ -423,6 +423,35 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].startupProbe
 
+  - it: omits dnsPolicy and dnsConfig by default
+    template: deployment.tpl
+    asserts:
+      - notExists:
+          path: spec.template.spec.dnsPolicy
+      - notExists:
+          path: spec.template.spec.dnsConfig
+
+  # ndots:1 keeps client.dns-resolver endpoints from walking the cluster DNS
+  # search list against the external resolver.
+  - it: sets dnsPolicy and dnsConfig when configured
+    template: deployment.tpl
+    set:
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirst
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].name
+          value: ndots
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].value
+          value: "1"
+
   - it: sets priorityClassName, grace, and a startup probe when configured
     template: deployment.tpl
     set:

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -1011,7 +1011,7 @@
     },
     "terminationGracePeriodSeconds": {
       "default": 30,
-      "description": "  options:\n    - name: ndots\n      value: \"1\"\nGrace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM).",
+      "description": "Grace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM).",
       "title": "terminationGracePeriodSeconds",
       "type": "integer"
     },

--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -35,6 +35,18 @@
       "title": "deploymentAnnotations",
       "type": "object"
     },
+    "dnsConfig": {
+      "description": "Pod dnsConfig (templated). Kubelet's default `ndots:5` makes the resolver walk the pod's DNS search list for every probe hostname, so each check burns extra guaranteed-NXDOMAIN lookups; when an endpoint template sets `client.dns-resolver`, that walk goes to the external resolver and leaks internal `\u003cnamespace\u003e.svc.cluster.local` names to it. Setting `ndots: \"1\"` (example below) makes external hostnames resolve directly.",
+      "required": [],
+      "title": "dnsConfig",
+      "type": "object"
+    },
+    "dnsPolicy": {
+      "default": "",
+      "description": "Pod dnsPolicy (templated); empty leaves it to Kubernetes (ClusterFirst). Only needed alongside `dnsConfig` overrides that require a specific policy (e.g. `None`).",
+      "title": "dnsPolicy",
+      "type": "string"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Override the full release name.",
@@ -999,7 +1011,7 @@
     },
     "terminationGracePeriodSeconds": {
       "default": 30,
-      "description": "Grace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM).",
+      "description": "  options:\n    - name: ndots\n      value: \"1\"\nGrace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM).",
       "title": "terminationGracePeriodSeconds",
       "type": "integer"
     },

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -306,6 +306,13 @@ tolerations: []
 affinity: {}
 # -- PriorityClass for the pod, so gatus is less likely to be preempted/evicted under node pressure. Empty uses the cluster default.
 priorityClassName: ""
+# -- Pod dnsPolicy (templated); empty leaves it to Kubernetes (ClusterFirst). Only needed alongside `dnsConfig` overrides that require a specific policy (e.g. `None`).
+dnsPolicy: ""
+# -- Pod dnsConfig (templated). Kubelet's default `ndots:5` makes the resolver walk the pod's DNS search list for every probe hostname, so each check burns extra guaranteed-NXDOMAIN lookups; when an endpoint template sets `client.dns-resolver`, that walk goes to the external resolver and leaks internal `<namespace>.svc.cluster.local` names to it. Setting `ndots: "1"` (example below) makes external hostnames resolve directly.
+dnsConfig: {}
+#   options:
+#     - name: ndots
+#       value: "1"
 # -- Grace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM).
 terminationGracePeriodSeconds: 30
 

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -313,6 +313,7 @@ dnsConfig: {}
 #   options:
 #     - name: ndots
 #       value: "1"
+
 # -- Grace period for a clean shutdown (gatus drains in-flight checks and closes its servers on SIGTERM).
 terminationGracePeriodSeconds: 30
 


### PR DESCRIPTION
Fixes #168.

Exposes `Pod.spec.dnsPolicy` and `Pod.spec.dnsConfig` in the chart. Both are omitted by default, so rendered output is unchanged for existing installs.

With kubelet's default `ndots:5`, every generated probe hostname walks the pod's DNS search list before resolving. For endpoints whose template sets `client.dns-resolver`, that NXDOMAIN walk goes to the external resolver (8 queries per check, 6 guaranteed NXDOMAIN) and leaks internal `<namespace>.svc.cluster.local` names to it. Until now the only mitigation was a post-render patch on the Deployment; this makes it a values-level opt-in:

```yaml
dnsConfig:
  options:
    - name: ndots
      value: "1"
```

The interaction is documented on the `dnsConfig` value (and lands in the generated README), covering the docs ask in the issue as well.

The trailing-dot approach suggested in the issue was deliberately not taken: Envoy does not strip a trailing dot from the Host header by default (unlike nginx), so routes matching `app.example.com` would not match `app.example.com.` and the probes this targets would start returning 404 ([Envoy Gateway host-normalization docs](https://gateway.envoyproxy.io/docs/tasks/traffic/host-header-normalization/)). The clean fix for everyone would be upstream in Gatus: root the name at resolution time only when `dns-resolver` is set, leaving the URL and Host header untouched.

- `helm unittest`: 55 passed (adds default-omission and rendering tests)
- `helm lint` / `helm template` smoke-checked; README and values.schema.json regenerated via `mise run generate`
