### PR TITLE
fix(chart): keep example comments out of unrelated schema descriptions

### DIFF
--- a/charts/gatus-sidecar/values.schema.json
+++ b/charts/gatus-sidecar/values.schema.json
@@ -75,7 +75,7 @@
           "type": "object"
         },
         "envFrom": {
-          "description": "  - name: GOMEMLIMIT\n    value: \"200MiB\"\nSources of environment variables for the gatus container (templated), e.g. a Secret holding buddy.yaml Pushover tokens.",
+          "description": "Sources of environment variables for the gatus container (templated), e.g. a Secret holding buddy.yaml Pushover tokens.",
           "items": {
             "required": []
           },
@@ -83,7 +83,7 @@
           "type": "array"
         },
         "extraEnv": {
-          "description": "  TZ: UTC\nExtra environment variables for the gatus container, as a raw list (templated).",
+          "description": "Extra environment variables for the gatus container, as a raw list (templated).",
           "items": {
             "required": []
           },
@@ -198,7 +198,7 @@
           "type": "object"
         },
         "securityContext": {
-          "description": "  - secretRef:\n      name: gatus-secrets\nGatus container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).",
+          "description": "Gatus container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).",
           "properties": {
             "allowPrivilegeEscalation": {
               "default": false,
@@ -255,7 +255,7 @@
       "description": "Gateway API HTTPRoute — an alternative to `ingress` for clusters using the\nGateway API. Renders one HTTPRoute pointing at the app service port. Named\n`httpRoute` (not `route`) to avoid confusion with the OpenShift Route kind.",
       "properties": {
         "additionalRules": {
-          "description": " - gatus.example.com\nCustom rules prepended before the default rule (templated).",
+          "description": "Custom rules prepended before the default rule (templated).",
           "items": {
             "required": []
           },
@@ -289,7 +289,7 @@
           "type": "array"
         },
         "hostnames": {
-          "description": " - name: gateway\n   namespace: gateway\n   sectionName: https\nHostnames matched against the Host header (templated).",
+          "description": "Hostnames matched against the Host header (templated).",
           "items": {
             "required": []
           },

--- a/charts/gatus-sidecar/values.yaml
+++ b/charts/gatus-sidecar/values.yaml
@@ -44,14 +44,17 @@ gatus:
   # -- Extra environment variables for the gatus container, as a map (templated), e.g. TZ or `${VAR}` substitution values referenced by your config.
   env: {}
   #   TZ: UTC
+
   # -- Extra environment variables for the gatus container, as a raw list (templated).
   extraEnv: []
   #   - name: GOMEMLIMIT
   #     value: "200MiB"
+
   # -- Sources of environment variables for the gatus container (templated), e.g. a Secret holding buddy.yaml Pushover tokens.
   envFrom: []
   #   - secretRef:
   #       name: gatus-secrets
+
   # -- Gatus container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).
   securityContext:
     allowPrivilegeEscalation: false
@@ -283,9 +286,11 @@ httpRoute:
   #  - name: gateway
   #    namespace: gateway
   #    sectionName: https
+
   # -- Hostnames matched against the Host header (templated).
   hostnames: []
   #  - gatus.example.com
+
   # -- Custom rules prepended before the default rule (templated).
   additionalRules: []
   # -- Filters applied to the default rule.


### PR DESCRIPTION
Follow-up to #169: applies the same blank-line treatment to the five pre-existing cases where helm-schema attaches a commented example block to the *next* key's description in `values.schema.json`:

- `gatus.env` example ("TZ: UTC") leaked into `gatus.extraEnv`
- `gatus.extraEnv` example (GOMEMLIMIT) leaked into `gatus.envFrom`
- `gatus.envFrom` example (secretRef) leaked into `gatus.securityContext`
- `httpRoute.parentRefs` example leaked into `httpRoute.hostnames`
- `httpRoute.hostnames` example leaked into `httpRoute.additionalRules`

These descriptions surface as hover docs in editors that consume the schema. A blank line after each example block stops helm-schema from carrying it forward; the examples themselves stay put. Verified via a schema-wide scan for descriptions starting with example content — none remain. `helm-docs` output (chart README) is byte-identical, `helm unittest` 55/55, `helm lint` clean.
