### PR TITLE
fix(go): update to go 1.27.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,8 +1,8 @@
 [tools]
 actionlint = "1.7.12"
-go = "1.26.6"
+go = "1.27.0"
 "go:golang.org/x/vuln/cmd/govulncheck" = "v1.7.0"
-golangci-lint = "2.12.2"
+golangci-lint = "2.13.0"
 helm = "4.2.4"
 cosign = "3.1.3"
 "aqua:dadav/helm-schema" = "0.23.4"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -64,45 +64,45 @@ url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/50328620
 provenance = "cosign"
 
 [[tools.go]]
-version = "1.26.6"
+version = "1.27.0"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e"
-url = "https://dl.google.com/go/go1.26.6.linux-arm64.tar.gz"
+checksum = "sha256:51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda"
+url = "https://dl.google.com/go/go1.27.0.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89"
-url = "https://dl.google.com/go/go1.26.6.linux-amd64.tar.gz"
+checksum = "sha256:675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685"
+url = "https://dl.google.com/go/go1.27.0.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:2dc95ce4675829f2df0e86b28bcef3283635902062a5f0580ca659bf570f3204"
-url = "https://dl.google.com/go/go1.26.6.darwin-arm64.tar.gz"
+checksum = "sha256:90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e"
+url = "https://dl.google.com/go/go1.27.0.darwin-arm64.tar.gz"
 
 [[tools."go:golang.org/x/vuln/cmd/govulncheck"]]
 version = "1.7.0"
 backend = "go:golang.org/x/vuln/cmd/govulncheck"
 
 [[tools.golangci-lint]]
-version = "2.12.2"
+version = "2.13.0"
 backend = "aqua:golangci/golangci-lint"
 
 [tools.golangci-lint."platforms.linux-arm64"]
-checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
+checksum = "sha256:3a91c7bb9c135099a97858bea431d6dd2f54e4bf68d479c776c2350428d60e41"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471362"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
-checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
+checksum = "sha256:a10e8d8359d76b9e2b41da60f9d98bb26fd53c7a453caa82e0a172d6f72fd2ca"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471346"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
-checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
+checksum = "sha256:72eae670097978e61b78a773a25c27439e35d54094fd986cee5eeeb25d7144fd"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471400"
 provenance = "github-attestations"
 
 [[tools.helm]]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/gatus-sidecar
 
-go 1.26.0
+go 1.27.0
 
 require (
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/resources/httproute_test.go
+++ b/internal/resources/httproute_test.go
@@ -17,7 +17,7 @@ import (
 
 func makeRoute(name string, hostnames []gatewayv1.Hostname, parentRefs []gatewayv1.ParentReference, annotations map[string]string) *gatewayv1.HTTPRoute {
 	return &gatewayv1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Annotations: annotations},
+		Name: name, Namespace: "default", Annotations: annotations,
 		Spec: gatewayv1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: parentRefs},
 			Hostnames:       hostnames,

--- a/internal/resources/ingress_test.go
+++ b/internal/resources/ingress_test.go
@@ -29,11 +29,9 @@ func makeIngressWithPaths(host string, tls bool, class *string, annotations map[
 		rule.HTTP = http
 	}
 	ing := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "ing",
-			Namespace:   "default",
-			Annotations: annotations,
-		},
+		Name:        "ing",
+		Namespace:   "default",
+		Annotations: annotations,
 		Spec: networkingv1.IngressSpec{
 			IngressClassName: class,
 			Rules:            []networkingv1.IngressRule{rule},
@@ -194,11 +192,11 @@ func TestIngressClassOf(t *testing.T) {
 		want string
 	}{
 		{"spec wins over legacy", &networkingv1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{legacyIngressClassAnnotation: "ignored"}},
-			Spec:       networkingv1.IngressSpec{IngressClassName: &nginx},
+			Annotations: map[string]string{legacyIngressClassAnnotation: "ignored"},
+			Spec:        networkingv1.IngressSpec{IngressClassName: &nginx},
 		}, "nginx"},
 		{"legacy fallback", &networkingv1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{legacyIngressClassAnnotation: "traefik"}},
+			Annotations: map[string]string{legacyIngressClassAnnotation: "traefik"},
 		}, "traefik"},
 		{"none", &networkingv1.Ingress{}, ""},
 	}

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/home-operations/gatus-sidecar/internal/config"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -110,7 +109,7 @@ func TestHasGatusAnnotations(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			obj := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: tt.ann}}
+			obj := &corev1.Service{Annotations: tt.ann}
 			if got := hasGatusAnnotations(obj, cfg); got != tt.want {
 				t.Errorf("hasGatusAnnotations() = %v, want %v", got, tt.want)
 			}

--- a/internal/resources/service_test.go
+++ b/internal/resources/service_test.go
@@ -12,7 +12,7 @@ import (
 
 func makeService(name, ns string, port int32, protocol corev1.Protocol) *corev1.Service {
 	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Name: name, Namespace: ns,
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{Port: port, Protocol: protocol}},
 		},
@@ -34,10 +34,10 @@ func TestService_URL(t *testing.T) {
 		{"dots-only cluster domain falls back to the default", makeService("a", "ns", 80, corev1.ProtocolTCP), ".", "tcp://a.ns.svc.cluster.local.:80"},
 		{"trailing dot on the configured domain is not doubled", makeService("a", "ns", 80, corev1.ProtocolTCP), "cluster.local.", "tcp://a.ns.svc.cluster.local.:80"},
 		{"default protocol", &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "n"},
-			Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
+			Name: "a", Namespace: "n",
+			Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 		}, "cluster.local", "tcp://a.n.svc.cluster.local.:80"},
-		{"no ports", &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "a"}}, "cluster.local", ""},
+		{"no ports", &corev1.Service{Name: "a"}, "cluster.local", ""},
 		{"wrong type", &corev1.Pod{}, "cluster.local", ""},
 	}
 	for _, tt := range cases {


### PR DESCRIPTION
Updates the toolchain to Go 1.27.0 and applies the new modernizers. Same change as home-operations/echo#84.

- Bump `go` to 1.27.0 in mise (full patch) and go.mod (minor), lockfile regenerated.
- Bump golangci-lint 2.12.2 → 2.13.0: 2.12.2 is built with go1.26 and refuses a 1.27 language target; 2.13.0 is built with go1.27.0.
- Apply the `embedlit` fixer from `go fix`: Go 1.27 allows promoted fields of embedded structs as struct-literal keys, so the `ObjectMeta: metav1.ObjectMeta{...}` wrappers in test fixtures are flattened to direct `Name`/`Namespace`/`Annotations` keys.

Verified locally: `go build`, `go vet`, `gofmt -l` (clean), `golangci-lint run` (0 issues), `go test -race ./...` (all pass), `govulncheck` (clean).