### PR TITLE
docs(readme): set GATUS_CONFIG_PATH so Gatus loads the sidecar file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,13 @@ gatus-sidecar \
 ## Deployment
 
 Run alongside Gatus, sharing a config volume. The sidecar writes
-`/config/gatus-sidecar.yaml`; configure Gatus to include it as a watched
-sub-config.
+`/config/gatus-sidecar.yaml`, which contains only `endpoints:`. Gatus has no
+include directive: by default it reads a single file, so set
+`GATUS_CONFIG_PATH` to the shared **directory**. Gatus then merges every
+`*.yaml`/`*.yml` in it (endpoint lists are appended, maps are deep-merged).
+Put the rest of your Gatus config (`alerting:`, `storage:`, `web:`, ...) in
+another file in the same directory, for example a ConfigMap mounted at
+`/config/config.yaml` with `subPath`, so it doesn't shadow the sidecar's file.
 
 ```yaml
 apiVersion: apps/v1
@@ -63,6 +68,8 @@ spec:
       containers:
         - name: gatus
           image: ghcr.io/twin/gatus:latest
+          env:
+            - { name: GATUS_CONFIG_PATH, value: /config }
           volumeMounts:
             - { name: gatus-config, mountPath: /config }
         - name: gatus-sidecar


### PR DESCRIPTION
The Deployment section told readers to "configure Gatus to include it as a watched sub-config", but Gatus has no include directive. Per its docs it reads a single file by default and only merges the `*.yaml`/`*.yml` files in a directory when `GATUS_CONFIG_PATH` points at that directory. The example manifest never set the variable, so a reader following it ends up with Gatus ignoring `gatus-sidecar.yaml` entirely, or working around it by pointing both containers at one `config.yaml`, which breaks as soon as a root `alerting:` section is needed.

- Rewrite the Deployment prose: the sidecar file only carries `endpoints:`, set `GATUS_CONFIG_PATH` to the shared directory, and keep the rest of the Gatus config (`alerting:`, `storage:`, `web:`) in another file there (e.g. a `subPath`-mounted ConfigMap so it doesn't shadow the sidecar's file).
- Add `GATUS_CONFIG_PATH=/config` to the gatus container in the example manifest, matching what the Helm chart already does.

Follow-up to #173 for the remaining docs gap raised in #172.

Closes #172